### PR TITLE
csp policy

### DIFF
--- a/build.go
+++ b/build.go
@@ -1,3 +1,3 @@
 package main
 
-const buildID = "v0.0.5, git+sha: 81b7def"
+const buildID = "v0.0.6, git+sha: 8f1b3d8"

--- a/doc.go
+++ b/doc.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	prog        = "keycloak-proxy"
-	version     = "v0.0.6"
+	version     = "v0.0.7"
 	author      = "Rohith"
 	email       = "gambol99@gmail.com"
 	description = "is a proxy using the keycloak service for auth and authorization"

--- a/handlers.go
+++ b/handlers.go
@@ -69,7 +69,6 @@ func (r *KeycloakProxy) securityHandler() gin.HandlerFunc {
 	secure := secure.New(secure.Options{
 		AllowedHosts:          r.config.Hostnames,
 		BrowserXssFilter:      true,
-		ContentSecurityPolicy: "default-src 'self'",
 		ContentTypeNosniff:    true,
 		FrameDeny:             true,
 	})

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 	kc := cli.NewApp()
 	kc.Name = prog
 	kc.Usage = description
-	kc.Version = buildID
+	kc.Version = version
 	kc.Author = author
 	kc.Email = email
 	kc.Flags = getOptions()


### PR DESCRIPTION
- removing the csp from the security handler
- pushing to version v0.0.7
- removing the build id, doesnt work well