### PR TITLE
customization changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,21 @@
 
+#### **1.0.5 (May 3th, 2016)**
 
-#### **1.0.3 (April 30th, 2016)**
+FEATURES:
+ * You can choose the cookie name of the access and refresh token via --cookie-{access,refresh}-name
+ * An additional option --add-claims to inject custom claims from the token into the authentication headers
+   i.e. --add-claims=given_name would add X-Auth-Given-Name (assumed the claims exists)
+ * Added the --secure-cookie option to control the 'secure' flag on the cookie
+ 
+BREAKING CHANGES:
+ * Changed the claims option from 'claims' to 'match-claims' (command line and config)
+ * Changed keepalive config option to the same as the command line 'keepalive' -> 'upstream-keepalives' 
+ * Changed the config option from 'upstream' to 'upstream-url', same as command line
+ 
+#### **1.0.4 (April 30th, 2016)**
 
 FIXES:
- * Fixes the cookie sessions expiraton
+ * Fixes the cookie sessions expiration
 
 FEATURES:
  * Adding a idle duration configuration option which controls the expiration of access token cookie and thus session. 

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -28,19 +28,33 @@ tls-ca-certificate:
 redirection-url: http://127.0.0.3000
 # the encryption key used to encode the session state
 encryption-key: vGcLt8ZUdPX5fXhtLZaPHZkGWHZrT6T8xKHWf5RPfqAocuiQ6nUbNHyc3oF2toO2tr
+# the name of the access cookie, defaults to kc-access
+access-cookie-name:
+# the name of the refresh cookie, default to kc-state
+refresh-cookie-name:
 # the upstream endpoint which we should proxy request
-upstream: http://127.0.0.1:80
+upstream-url: http://127.0.0.1:80
 # upstream-keepalives specified wheather you want keepalive on the upstream endpoint
 upstream-keepalives: true
+# skip the tls verification of the upstream url
+skip-upstream-tls-verify: true|false
 # additional scopes to add to add to the default (openid+email+profile)
 scopes: []
 # enables a more extra secuirty features
 enable-security-filter: true
+# headers permits you to inject custom headers into all request
+headers:
+  myheader_name: my_header_value
 # a map of claims that MUST exist in the token presented and the value is it MUST match
 # So for example, you could match the audience or the issuer or some custom attribute
-claims:
+match-claims:
   aud: openvpn
   iss: https://keycloak.example.com/auth/realms/commons
+# a list of claims to inject into the authentication headers i.e. given_name -> X-Auth-Given-Name
+add-claims:
+- given_name
+- family_name
+- name
 # a collection of resource i.e. urls that you wish to protect
 resources:
   - url: /admin/test

--- a/config_test.go
+++ b/config_test.go
@@ -46,7 +46,7 @@ secret: <secret>
 discovery_url: https://keyclock.domain.com
 client-id: <client_id>
 secret: <secret>
-upstream: http://127.0.0.1:8080
+upstream-url: http://127.0.0.1:8080
 redirection_url: http://127.0.0.1:3000
 `,
 			Ok: true,
@@ -116,7 +116,7 @@ func TestIsConfig(t *testing.T) {
 				ClientSecret:   "client",
 				RedirectionURL: "http://120.0.0.1",
 				Upstream:       "http://120.0.0.1",
-				ClaimsMatch: map[string]string{
+				MatchClaims: map[string]string{
 					"test": "&&&[",
 				},
 			},

--- a/cookies.go
+++ b/cookies.go
@@ -20,19 +20,18 @@ import (
 	"strings"
 	"time"
 
-	"github.com/coreos/go-oidc/jose"
 	"github.com/gin-gonic/gin"
 )
 
 //
 // dropCookie drops a cookie into the response
 //
-func dropCookie(cx *gin.Context, name, value string, duration time.Duration, secure bool) {
+func (r oauthProxy) dropCookie(cx *gin.Context, name, value string, duration time.Duration) {
 	cookie := &http.Cookie{
 		Name:   name,
 		Domain: strings.Split(cx.Request.Host, ":")[0],
 		Path:   "/",
-		Secure: secure,
+		Secure: r.config.SecureCookie,
 		Value:  value,
 	}
 	if duration != 0 {
@@ -45,35 +44,35 @@ func dropCookie(cx *gin.Context, name, value string, duration time.Duration, sec
 //
 // dropAccessTokenCookie drops a access token cookie into the response
 //
-func dropAccessTokenCookie(cx *gin.Context, token jose.JWT, duration time.Duration, secure bool) {
-	dropCookie(cx, cookieAccessToken, token.Encode(), duration, secure)
+func (r oauthProxy) dropAccessTokenCookie(cx *gin.Context, value string, duration time.Duration) {
+	r.dropCookie(cx, r.config.CookieAccessName, value, duration)
 }
 
 //
 // dropRefreshTokenCookie drops a refresh token cookie into the response
 //
-func dropRefreshTokenCookie(cx *gin.Context, token string, duration time.Duration, secure bool) {
-	dropCookie(cx, cookieRefreshToken, token, duration, secure)
+func (r oauthProxy) dropRefreshTokenCookie(cx *gin.Context, value string, duration time.Duration) {
+	r.dropCookie(cx, r.config.CookieRefreshName, value, duration)
 }
 
 //
 // clearAllCookies is just a helper function for the below
 //
-func clearAllCookies(cx *gin.Context, secure bool) {
-	clearAccessTokenCookie(cx, secure)
-	clearRefreshTokenCookie(cx, secure)
+func (r oauthProxy) clearAllCookies(cx *gin.Context) {
+	r.clearAccessTokenCookie(cx)
+	r.clearRefreshTokenCookie(cx)
 }
 
 //
 // clearRefreshSessionCookie clears the session cookie
 //
-func clearRefreshTokenCookie(cx *gin.Context, secure bool) {
-	dropCookie(cx, cookieRefreshToken, "", time.Duration(-10*time.Hour), secure)
+func (r oauthProxy) clearRefreshTokenCookie(cx *gin.Context) {
+	r.dropCookie(cx, r.config.CookieRefreshName, "", time.Duration(-10*time.Hour))
 }
 
 //
 // clearAccessTokenCookie clears the session cookie
 //
-func clearAccessTokenCookie(cx *gin.Context, secure bool) {
-	dropCookie(cx, cookieAccessToken, "", time.Duration(-10*time.Hour), secure)
+func (r oauthProxy) clearAccessTokenCookie(cx *gin.Context) {
+	r.dropCookie(cx, r.config.CookieAccessName, "", time.Duration(-10*time.Hour))
 }

--- a/cookies_test.go
+++ b/cookies_test.go
@@ -22,46 +22,53 @@ import (
 )
 
 func TestDropCookie(t *testing.T) {
+	p := newFakeKeycloakProxy(t)
+
 	context := newFakeGinContext("GET", "/admin")
-	dropCookie(context, "test-cookie", "test-value", 0, true)
+	p.dropCookie(context, "test-cookie", "test-value", 0)
 
 	assert.Equal(t, context.Writer.Header().Get("Set-Cookie"),
 		"test-cookie=test-value; Path=/; Domain=127.0.0.1; Secure",
 		"we have not set the cookie, headers: %v", context.Writer.Header())
 
 	context = newFakeGinContext("GET", "/admin")
-	dropCookie(context, "test-cookie", "test-value", 0, false)
+	p.config.SecureCookie = false
+	p.dropCookie(context, "test-cookie", "test-value", 0)
 
 	assert.Equal(t, context.Writer.Header().Get("Set-Cookie"),
 		"test-cookie=test-value; Path=/; Domain=127.0.0.1",
 		"we have not set the cookie, headers: %v", context.Writer.Header())
 
 	context = newFakeGinContext("GET", "/admin")
-	dropCookie(context, "test-cookie", "test-value", 0, true)
+	p.config.SecureCookie = true
+	p.dropCookie(context, "test-cookie", "test-value", 0)
 	assert.NotEqual(t, context.Writer.Header().Get("Set-Cookie"),
 		"test-cookie=test-value; Path=/; Domain=127.0.0.2; HttpOnly; Secure",
 		"we have not set the cookie, headers: %v", context.Writer.Header())
 }
 
 func TestClearAccessTokenCookie(t *testing.T) {
+	p := newFakeKeycloakProxy(t)
 	context := newFakeGinContext("GET", "/admin")
-	clearAccessTokenCookie(context, true)
+	p.clearAccessTokenCookie(context)
 	assert.Contains(t, context.Writer.Header().Get("Set-Cookie"),
 		"kc-access=; Path=/; Domain=127.0.0.1; Expires=",
 		"we have not cleared the, headers: %v", context.Writer.Header())
 }
 
 func TestClearRefreshAccessTokenCookie(t *testing.T) {
+	p := newFakeKeycloakProxy(t)
 	context := newFakeGinContext("GET", "/admin")
-	clearRefreshTokenCookie(context, true)
+	p.clearRefreshTokenCookie(context)
 	assert.Contains(t, context.Writer.Header().Get("Set-Cookie"),
 		"kc-state=; Path=/; Domain=127.0.0.1; Expires=",
 		"we have not cleared the, headers: %v", context.Writer.Header())
 }
 
 func TestClearAllCookies(t *testing.T) {
+	p := newFakeKeycloakProxy(t)
 	context := newFakeGinContext("GET", "/admin")
-	clearAllCookies(context, true)
+	p.clearAllCookies(context)
 	assert.Contains(t, context.Writer.Header().Get("Set-Cookie"),
 		"kc-access=; Path=/; Domain=127.0.0.1; Expires=",
 		"we have not cleared the, headers: %v", context.Writer.Header())

--- a/doc.go
+++ b/doc.go
@@ -114,16 +114,22 @@ type Config struct {
 	EnableSecurityFilter bool `json:"enable-security-filter" yaml:"enable-security-filter"`
 	// EnableRefreshTokens indicate's you wish to ignore using refresh tokens and re-auth on expireation of access token
 	EnableRefreshTokens bool `json:"enable-refresh-tokens" yaml:"enable-refresh-tokens"`
+	// CookieAccessName is the name of the access cookie holding the access token
+	CookieAccessName string `json:"cookie-access-name" yaml:"cookie-access-name"`
+	// CookieRefreshName is the name of the refresh cookie
+	CookieRefreshName string `json:"cookie-refresh-name" yaml:"cookie-refresh-name"`
+	// SecureCookie enforces the cookie as secure
+	SecureCookie bool `json:"secure-cookie" yaml:"secure-cookie"`
 	// IdleDuration is the max amount of time a session can last without being used
 	IdleDuration time.Duration `json:"idle-duration" yaml:"idle-duration"`
 	// EncryptionKey is the encryption key used to encrypt the refresh token
 	EncryptionKey string `json:"encryption-key" yaml:"encryption-key"`
-	// SecureCookie enforces the cookie as secure
-	SecureCookie bool `json:"secure-cookie" yaml:"secure-cookie"`
-	// ClaimsMatch is a series of checks, the claims in the token must match those here
-	ClaimsMatch map[string]string `json:"claims" yaml:"claims"`
-	// Keepalives specifies wheather we use keepalives on the upstream
-	Keepalives bool `json:"keepalives" yaml:"keepalives"`
+	// MatchClaims is a series of checks, the claims in the token must match those here
+	MatchClaims map[string]string `json:"match-claims" yaml:"match-claims"`
+	// AddClaims is a series of claims that should be added to the auth headers
+	AddClaims []string `json:"add-claims" yaml:"add-claims"`
+	// UpstreamKeepalives specifies wheather we use keepalives on the upstream
+	UpstreamKeepalives bool `json:"upstream-keepalives" yaml:"upstream-keepalives"`
 	// Listen is the binding interface
 	Listen string `json:"listen" yaml:"listen"`
 	// ProxyProtocol enables proxy protocol
@@ -137,13 +143,13 @@ type Config struct {
 	// SkipUpstreamTLSVerify skips the verification of any upstream tls
 	SkipUpstreamTLSVerify bool `json:"skip-upstream-tls-verify" yaml:"skip-upstream-tls-verify"`
 	// Upstream is the upstream endpoint i.e whom were proxying to
-	Upstream string `json:"upstream" yaml:"upstream"`
+	Upstream string `json:"upstream-url" yaml:"upstream-url"`
 	// TagData is passed to the templates
 	TagData map[string]string `json:"tag-data" yaml:"tag-data"`
 	// CrossOrigin permits adding headers to the /oauth handlers
 	CrossOrigin CORS `json:"cors" yaml:"cors"`
-	// Header permits adding customs headers across the board
-	Header map[string]string `json:"headers" yaml:"headers"`
+	// Headers permits adding customs headers across the board
+	Headers map[string]string `json:"headers" yaml:"headers"`
 	// Scopes is a list of scope we should request
 	Scopes []string `json:"scopes" yaml:"scopes"`
 	// Resources is a list of protected resources

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -444,7 +444,7 @@ func TestAdmissionHandlerClaims(t *testing.T) {
 
 	for i, c := range tests {
 		// step: if closure so we need to get the handler each time
-		proxy.config.ClaimsMatch = c.Matches
+		proxy.config.MatchClaims = c.Matches
 		handler := proxy.admissionHandler()
 		// step: inject a resource
 

--- a/server.go
+++ b/server.go
@@ -123,7 +123,7 @@ func newProxy(cfg *Config) (*oauthProxy, error) {
 	for _, resource := range cfg.Resources {
 		log.Infof("protecting resources under uri: %s", resource)
 	}
-	for name, value := range cfg.ClaimsMatch {
+	for name, value := range cfg.MatchClaims {
 		log.Infof("the token must container the claim: %s, required: %s", name, value)
 	}
 
@@ -249,7 +249,7 @@ func (r *oauthProxy) setupReverseProxy(upstream *url.URL) (reverseProxy, error) 
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: r.config.SkipUpstreamTLSVerify,
 		},
-		DisableKeepAlives: !r.config.Keepalives,
+		DisableKeepAlives: !r.config.UpstreamKeepalives,
 	}
 
 	return proxy, nil

--- a/server_test.go
+++ b/server_test.go
@@ -60,6 +60,9 @@ func newFakeKeycloakConfig(t *testing.T) *Config {
 		SkipTokenVerification: true,
 		Scopes:                []string{},
 		EnableRefreshTokens:   false,
+		SecureCookie:          true,
+		CookieAccessName:      cookieAccessToken,
+		CookieRefreshName:     cookieRefreshToken,
 		Resources: []*Resource{
 			{
 				URL:     fakeAdminRoleURL,

--- a/session.go
+++ b/session.go
@@ -26,16 +26,16 @@ import (
 //
 // getIdentity retrieves the user identity from a request, either from a session cookie or a bearer token
 //
-func getIdentity(cx *gin.Context) (*userContext, error) {
+func (r oauthProxy) getIdentity(cx *gin.Context) (*userContext, error) {
 	// step: check for a bearer token or cookie with jwt token
 	isBearer := false
-	token, err := getAccessTokenFromCookie(cx)
+	token, err := r.getAccessTokenFromCookie(cx)
 	if err != nil {
 		if err != ErrSessionNotFound {
 			return nil, err
 		}
 		// step: else attempt to grab token from the bearer token]
-		token, err = getTokenFromBearer(cx)
+		token, err = r.getTokenFromBearer(cx)
 		if err != nil {
 			return nil, err
 		}
@@ -63,7 +63,7 @@ func getIdentity(cx *gin.Context) (*userContext, error) {
 //
 // getTokenFromBearer attempt to retrieve token from bearer token
 //
-func getTokenFromBearer(cx *gin.Context) (jose.JWT, error) {
+func (r oauthProxy) getTokenFromBearer(cx *gin.Context) (jose.JWT, error) {
 	auth := cx.Request.Header.Get(authorizationHeader)
 	if auth == "" {
 		return jose.JWT{}, ErrSessionNotFound
@@ -80,8 +80,8 @@ func getTokenFromBearer(cx *gin.Context) (jose.JWT, error) {
 //
 // getAccessTokenFromCookie attempt to grab access token from cookie
 //
-func getAccessTokenFromCookie(cx *gin.Context) (jose.JWT, error) {
-	cookie := findCookie(cookieAccessToken, cx.Request.Cookies())
+func (r oauthProxy) getAccessTokenFromCookie(cx *gin.Context) (jose.JWT, error) {
+	cookie := findCookie(r.config.CookieAccessName, cx.Request.Cookies())
 	if cookie == nil {
 		return jose.JWT{}, ErrSessionNotFound
 	}
@@ -90,10 +90,10 @@ func getAccessTokenFromCookie(cx *gin.Context) (jose.JWT, error) {
 }
 
 //
-// getRefreshTokenFromCookie
+// getRefreshTokenFromCookie returns the refresh token from the cookie if any
 //
-func getRefreshTokenFromCookie(cx *gin.Context) (string, error) {
-	cookie := findCookie(cookieRefreshToken, cx.Request.Cookies())
+func (r oauthProxy) getRefreshTokenFromCookie(cx *gin.Context) (string, error) {
+	cookie := findCookie(r.config.CookieRefreshName, cx.Request.Cookies())
 	if cookie == nil {
 		return "", ErrSessionNotFound
 	}

--- a/session_test.go
+++ b/session_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestGetSessionToken(t *testing.T) {
+	p := newFakeKeycloakProxy(t)
 	token := getFakeAccessToken(t)
 	encoded := token.Encode()
 
@@ -53,7 +54,7 @@ func TestGetSessionToken(t *testing.T) {
 	}
 
 	for i, c := range testCases {
-		user, err := getIdentity(c.Context)
+		user, err := p.getIdentity(c.Context)
 		if err != nil && c.Ok {
 			t.Errorf("test case %d should not have errored", i)
 			continue
@@ -68,6 +69,7 @@ func TestGetSessionToken(t *testing.T) {
 }
 
 func TestGetRefreshTokenFromCookie(t *testing.T) {
+	p := newFakeKeycloakProxy(t)
 	cases := []struct {
 		Cookies  []*http.Cookie
 		Expected string
@@ -102,7 +104,7 @@ func TestGetRefreshTokenFromCookie(t *testing.T) {
 	for i, x := range cases {
 		context := newFakeGinContextWithCookies("GET", "/", x.Cookies)
 
-		token, err := getRefreshTokenFromCookie(context)
+		token, err := p.getRefreshTokenFromCookie(context)
 		if err != nil && x.Ok {
 			t.Errorf("case %d, should not have thrown an error: %s, headers: %v", i, err, context.Writer.Header())
 			continue

--- a/util_test.go
+++ b/util_test.go
@@ -194,42 +194,6 @@ func TestContainedIn(t *testing.T) {
 	assert.True(t, containedIn("1", []string{"1", "2", "3", "4"}))
 }
 
-func TestValidateResources(t *testing.T) {
-	testCases := []struct {
-		Resources []*Resource
-		Ok        bool
-	}{
-		{
-			Resources: []*Resource{
-				{
-					URL: "/test",
-				},
-				{
-					URL:     "/test1",
-					Methods: []string{},
-				},
-			},
-			Ok: true,
-		},
-		{
-			Resources: []*Resource{
-				{
-					URL: "/test",
-				},
-				{},
-			},
-		},
-	}
-
-	for i, c := range testCases {
-		err := validateResources(c.Resources)
-		if err != nil && c.Ok {
-			t.Errorf("case %d should not have failed", i)
-			continue
-		}
-	}
-}
-
 func TestFileExists(t *testing.T) {
 	if fileExists("no_such_file_exsit_32323232") {
 		t.Errorf("we should have received false")
@@ -257,6 +221,54 @@ func TestIsUpgradedConnection(t *testing.T) {
 	assert.False(t, isUpgradedConnection(&http.Request{Header: header}))
 	header.Set(headerUpgrade, "set")
 	assert.True(t, isUpgradedConnection(&http.Request{Header: header}))
+}
+
+func TestToHeader(t *testing.T) {
+	cases := []struct {
+		Word     string
+		Expected string
+	}{
+		{
+			Word:     "given_name",
+			Expected: "Given-Name",
+		},
+		{
+			Word:     "family%name",
+			Expected: "Family-Name",
+		},
+		{
+			Word:     "perferredname",
+			Expected: "Perferredname",
+		},
+	}
+	for i, x := range cases {
+		assert.Equal(t, x.Expected, toHeader(x.Word), "case %d, expected: %s but got: %s",
+			i, x.Expected, toHeader(x.Word))
+	}
+}
+
+func TestCapitalize(t *testing.T) {
+	cases := []struct {
+		Word     string
+		Expected string
+	}{
+		{
+			Word:     "given",
+			Expected: "Given",
+		},
+		{
+			Word:     "1iven",
+			Expected: "1iven",
+		},
+		{
+			Word:     "Test this",
+			Expected: "Test this",
+		},
+	}
+	for i, x := range cases {
+		assert.Equal(t, x.Expected, capitalize(x.Word), "case %d, expected: %s but got: %s", i, x.Expected,
+			capitalize(x.Word))
+	}
 }
 
 func getFakeURL(location string) *url.URL {


### PR DESCRIPTION
- adding the ability to change the access and refresh cookies
- adding the ability to control the secure flag of the cookie
- adding the ability to inject custom claims from the access token into the authenticated headers
- updating the readme to reflect the changes
- changed the claims option to match-claims
- added the headers command line option as it was missing
- updated the example config_sample.yml
- adding additional unit tests where i could