### PR TITLE
host header in reverse proxy

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -386,6 +386,14 @@ func (r oauthProxy) proxyHandler() gin.HandlerFunc {
 			return
 		}
 
+		/*
+		Issue: https://github.com/golang/go/issues/7618
+
+		The reverse proxy does not update the Host header of request, as it's assumed the upstream in on the
+		same domain as the proxy. We could override the Director method, but the latter is easier
+		*/
+		cx.Request.Host = r.endpoint.Host
+
 		r.upstream.ServeHTTP(cx.Writer, cx.Request)
 	}
 }

--- a/handlers.go
+++ b/handlers.go
@@ -387,10 +387,10 @@ func (r oauthProxy) proxyHandler() gin.HandlerFunc {
 		}
 
 		/*
-		Issue: https://github.com/golang/go/issues/7618
+			Issue: https://github.com/golang/go/issues/7618
 
-		The reverse proxy does not update the Host header of request, as it's assumed the upstream in on the
-		same domain as the proxy. We could override the Director method, but the latter is easier
+			The reverse proxy does not update the Host header of request, as it's assumed the upstream in on the
+			same domain as the proxy. We could override the Director method, but the latter is easier
 		*/
 		cx.Request.Host = r.endpoint.Host
 

--- a/server_test.go
+++ b/server_test.go
@@ -48,6 +48,9 @@ const (
 func newFakeKeycloakProxyWithResources(t *testing.T, resources []*Resource) *oauthProxy {
 	kc := newFakeKeycloakProxy(t)
 	kc.config.Resources = resources
+	kc.endpoint = &url.URL{
+		Host: "127.0.0.1",
+	}
 	return kc
 }
 
@@ -107,6 +110,7 @@ func newFakeKeycloakProxy(t *testing.T) *oauthProxy {
 	kc := &oauthProxy{
 		config:   newFakeKeycloakConfig(t),
 		upstream: new(fakeReverseProxy),
+		endpoint: &url.URL{Host: "127.0.0.1"},
 	}
 	kc.router = gin.New()
 	gin.SetMode(gin.ReleaseMode)

--- a/tests/gen_token.go
+++ b/tests/gen_token.go
@@ -1,0 +1,1 @@
+package tests


### PR DESCRIPTION
- fixing the host header issue, the default behaviour of reverse proxy is not to set the Host header