### PR TITLE
config invalid for secure-cookie

### DIFF
--- a/config.go
+++ b/config.go
@@ -94,6 +94,9 @@ func (r *Config) isValid() error {
 		if r.EnableRefreshTokens && (len(r.EncryptionKey) != 16 && len(r.EncryptionKey) != 32) {
 			return fmt.Errorf("the encryption key (%d) must be either 16 or 32 characters for AES-128/AES-256 selection", len(r.EncryptionKey))
 		}
+		if r.SecureCookie && !strings.HasPrefix(r.RedirectionURL, "https") {
+			return fmt.Errorf("the cookie is set to secure but your redirection url is non-tls")
+		}
 		if r.StoreURL != "" {
 			if _, err := url.Parse(r.StoreURL); err != nil {
 				return fmt.Errorf("the store url is invalid, error: %s", err)

--- a/config_test.go
+++ b/config_test.go
@@ -157,6 +157,29 @@ func TestIsConfig(t *testing.T) {
 				Upstream:       "this should fail",
 			},
 		},
+		{
+			Config: &Config{
+				Listen:         ":8080",
+				DiscoveryURL:   "http://127.0.0.1:8080",
+				ClientID:       "client",
+				ClientSecret:   "client",
+				RedirectionURL: "http://120.0.0.1",
+				Upstream:       "this should fail",
+				SecureCookie:   true,
+			},
+		},
+		{
+			Config: &Config{
+				Listen:         ":8080",
+				DiscoveryURL:   "http://127.0.0.1:8080",
+				ClientID:       "client",
+				ClientSecret:   "client",
+				RedirectionURL: "https://120.0.0.1",
+				Upstream:       "this should fail",
+				SecureCookie:   true,
+			},
+			Ok: true,
+		},
 	}
 
 	for i, c := range tests {


### PR DESCRIPTION
- the configuration should be invalid if the redirection-url i.e. the site is non-ssl but the secure-cookie option is set true