### PR TITLE
- cleaning up the grammer, typos in the readme

### DIFF
--- a/kube/forwarding-rc.yml
+++ b/kube/forwarding-rc.yml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: keycloak-proxy
+  labels:
+    name: keycloak-proxy
+spec:
+  replicas: 1
+  selector:
+    name: keycloak-proxy
+  template:
+    metadata:
+      labels:
+        name: keycloak-proxy
+    spec:
+      containers:
+      - name: keycloak-proxy
+        image: quay.io/gambol99/keycloak-proxy:latest
+        imagePullPolicy: Always
+        args:
+          - --config /etc/secrets/forwarding.yml
+          #- --discovery-url https://sso.example.com/auth/realms/hod-test
+          - --client-id broker
+          #- --client-secret
+          - --listen 127.0.0.1:3000
+          - --enable-forwarding true
+          #- --forwarding-username username
+          #- --forwarding-password password
+          - --log-requests true
+          - --log-json-format true
+          - --verbose true
+        volumeMounts:
+        - name: secrets
+          mountPath: /etc/secrets
+      volumes:
+      - name: secrets
+        secret:
+          secretName: config

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -149,7 +149,8 @@ func TestEntrypointWhiteListing(t *testing.T) {
 }
 
 func TestEntrypointHandler(t *testing.T) {
-	proxy := newFakeKeycloakProxy(t)
+	proxy, _, _ := newTestProxyService(t, nil)
+
 	handler := proxy.entryPointHandler()
 
 	tests := []struct {

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/coreos/go-oidc/jose"
+	"github.com/coreos/go-oidc/oauth2"
 	"github.com/gin-gonic/gin"
 )
 
@@ -219,12 +220,31 @@ func (r *fakeOAuthServer) tokenHandler(cx *gin.Context) {
 		return
 	}
 
-	cx.JSON(http.StatusOK, tokenResponse{
-		IDToken:      token.Encode(),
-		AccessToken:  token.Encode(),
-		RefreshToken: token.Encode(),
-		ExpiresIn:    expiration.Second(),
-	})
+	switch cx.PostForm("grant_type") {
+	case oauth2.GrantTypeUserCreds:
+		username := cx.PostForm("username")
+		password := cx.PostForm("password")
+		if username == "" || password == "" {
+			cx.AbortWithStatus(http.StatusBadRequest)
+			return
+		}
+		cx.JSON(http.StatusOK, tokenResponse{
+			IDToken:      token.Encode(),
+			AccessToken:  token.Encode(),
+			RefreshToken: token.Encode(),
+			ExpiresIn:    expiration.Second(),
+		})
+	case oauth2.GrantTypeAuthCode:
+		cx.JSON(http.StatusOK, tokenResponse{
+			IDToken:      token.Encode(),
+			AccessToken:  token.Encode(),
+			RefreshToken: token.Encode(),
+			ExpiresIn:    expiration.Second(),
+		})
+	default:
+		fmt.Println("dsdsd")
+		cx.AbortWithStatus(http.StatusBadRequest)
+	}
 }
 
 func getRandomString(n int) string {

--- a/server.go
+++ b/server.go
@@ -163,6 +163,10 @@ func createReverseProxy(config *Config, service *oauthProxy) error {
 func createForwardingProxy(config *Config, service *oauthProxy) error {
 	log.Infof("enabled forward signing proxy mode")
 
+	if config.SkipUpstreamTLSVerify {
+		log.Warnf("TLS verification switched off; in forward signing mode it's recommended you verify! (--skip-upstream-tls-verify=false)")
+	}
+
 	// step: initialize the reverse http proxy
 	if err := service.createUpstreamProxy(nil); err != nil {
 		return err

--- a/session_test.go
+++ b/session_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestGetSessionToken(t *testing.T) {
 	p := newFakeKeycloakProxy(t)
-	token := getFakeAccessToken(t)
+	token := getFakeAccessToken()
 	encoded := token.Encode()
 
 	testCases := []struct {

--- a/user_context_test.go
+++ b/user_context_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func getFakeAccessToken(t *testing.T) jose.JWT {
-	testToken, err := jose.NewJWT(
+func getFakeAccessToken() jose.JWT {
+	testToken, _ := jose.NewJWT(
 		jose.JOSEHeader{
 			"alg": "RS256",
 		},
@@ -55,9 +55,6 @@ func getFakeAccessToken(t *testing.T) jose.JWT {
 			"given_name":         "Rohith",
 		},
 	)
-	if err != nil {
-		t.Fatalf("unable to generate a token: %s", err)
-	}
 
 	return testToken
 }
@@ -150,7 +147,7 @@ func TestIsBearerToken(t *testing.T) {
 }
 
 func TestGetUserContext(t *testing.T) {
-	context, err := extractIdentity(getFakeAccessToken(t))
+	context, err := extractIdentity(getFakeAccessToken())
 	assert.NoError(t, err)
 	assert.NotNil(t, context)
 	assert.Equal(t, "1e11e539-8256-4b3b-bda8-cc0d56cddb48", context.id)
@@ -159,6 +156,13 @@ func TestGetUserContext(t *testing.T) {
 	roles := []string{"openvpn:dev-vpn"}
 	if !reflect.DeepEqual(context.roles, roles) {
 		t.Errorf("the claims are not the same, %v <-> %v", context.roles, roles)
+	}
+}
+
+func BenchmarkExtractIdentity(b *testing.B) {
+	token := getFakeAccessToken()
+	for n := 0; n < b.N; n++ {
+		extractIdentity(token)
 	}
 }
 

--- a/util_test.go
+++ b/util_test.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"bytes"
+	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -29,8 +30,9 @@ import (
 )
 
 func TestCreateOpenIDClient(t *testing.T) {
+	_, auth, _ := newTestProxyService(t, nil)
 	client, _, err := createOpenIDClient(&Config{
-		DiscoveryURL: newFakeOAuthServer(t).getLocation(),
+		DiscoveryURL: auth.location.String() + "/auth/realms/hod-test",
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, client)
@@ -209,7 +211,14 @@ func TestContainsSubString(t *testing.T) {
 }
 
 func BenchmarkContainsSubString(t *testing.B) {
-	containsSubString("svc.cluster.local", []string{"nginx.pr1.svc.cluster.local"})
+	for n := 0; n < t.N; n++ {
+		containsSubString("svc.cluster.local", []string{"nginx.pr1.svc.cluster.local"})
+	}
+}
+
+func TestCloneTLSConfig(t *testing.T) {
+	assert.NotNil(t, cloneTLSConfig(nil))
+	assert.NotNil(t, cloneTLSConfig(&tls.Config{}))
 }
 
 func TestDialAddress(t *testing.T) {


### PR DESCRIPTION
- adding test for the login and token handlers
- permitting the oauth test service to handle user credentials and auth code
- adding the warning message when forwarding enabled and tls verfication off
- adding a benchmark for the extract identity