### PR TITLE
discard http logging

### DIFF
--- a/server.go
+++ b/server.go
@@ -36,6 +36,7 @@ import (
 	"github.com/coreos/go-oidc/oidc"
 	"github.com/elazarl/goproxy"
 	"github.com/gin-gonic/gin"
+	httplog "log"
 )
 
 type oauthProxy struct {
@@ -78,6 +79,9 @@ func newProxy(config *Config) (*oauthProxy, error) {
 	if config.Verbose {
 		log.SetLevel(log.DebugLevel)
 	}
+	// step: disable the logging for http server - stop us from getting all those
+	// annoying EOF from tcp health checks
+	httplog.SetOutput(ioutil.Discard)
 
 	log.Infof("starting %s, author: %s, version: %s, ", prog, author, version)
 

--- a/templates/forbidden.html.tmpl
+++ b/templates/forbidden.html.tmpl
@@ -24,7 +24,7 @@
           <h1 class="oops">Oops!</h1>
           <h2 class="message">503 Permission Denied</h2>
           <div class="error-details">
-            Sorry, you do not have accces to this page, please consult with the application administrator
+            Sorry, you do not have access to this page, please contact your administrator
           </div>
         </div>
       </div>


### PR DESCRIPTION
- switching off the logging for default log package, this stops all those
  annoying elb checks from appearing