### PR TITLE
client certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 FEATURES:
  * Added a prometheus metrics endpoint, at present a break down by status_code is provided
  * Added the ability to override the cookie domain from the default host header
+ * Added the ability to load a client certificate used by the reverse and forwarding upstream 
+   proxies.
+
+TODO:
+ * Need a means to updating the client certificate once expired.
  
 CHANGES:
  * Updated the godeps for codegangsta cli to it's renamed version

--- a/config.go
+++ b/config.go
@@ -66,6 +66,9 @@ func (r *Config) isValid() error {
 	if r.TLSCaCertificate != "" && !fileExists(r.TLSCaCertificate) {
 		return fmt.Errorf("the tls ca certificate file %s does not exist", r.TLSCaCertificate)
 	}
+	if r.TLSClientCertificate != "" && !fileExists(r.TLSClientCertificate) {
+		return fmt.Errorf("the tls client certificate %s does not exist", r.TLSClientCertificate)
+	}
 
 	if r.EnableForwarding {
 		if r.ClientID == "" {
@@ -225,6 +228,9 @@ func readOptions(cx *cli.Context, config *Config) (err error) {
 	}
 	if cx.IsSet("tls-ca-certificate") {
 		config.TLSCaCertificate = cx.String("tls-ca-certificate")
+	}
+	if cx.IsSet("tls-client-certificate") {
+		config.TLSClientCertificate = cx.String("tls-client-certificate")
 	}
 	if cx.IsSet("enable-metrics") {
 		config.EnableMetrics = cx.Bool("enable-metrics")
@@ -489,6 +495,10 @@ func getOptions() []cli.Flag {
 		cli.StringFlag{
 			Name:  "tls-ca-certificate",
 			Usage: "the path to the ca certificate used for mutual TLS",
+		},
+		cli.StringFlag{
+			Name:  "tls-client-certificate",
+			Usage: "the path to the client certificate, used to outbound connections in reverse and forwarding proxy modes",
 		},
 		cli.BoolTFlag{
 			Name:  "skip-upstream-tls-verify",

--- a/doc.go
+++ b/doc.go
@@ -147,6 +147,8 @@ type Config struct {
 	TLSPrivateKey string `json:"tls-private-key" yaml:"tls-private-key"`
 	// TLSCaCertificate is the CA certificate which the client cert must be signed
 	TLSCaCertificate string `json:"tls-ca-certificate" yaml:"tls-ca-certificate"`
+	// TLSClientCertificate is path to a client certificate to use for outbound connections
+	TLSClientCertificate string `json:"tls-client-certificate" yaml:"tls-client-certificate"`
 	// SkipUpstreamTLSVerify skips the verification of any upstream tls
 	SkipUpstreamTLSVerify bool `json:"skip-upstream-tls-verify" yaml:"skip-upstream-tls-verify"`
 


### PR DESCRIPTION
- adding the command line options -tls-client-ceritificate to load a client cert for upstream forwarding and reverse proxy