### PR TITLE
Res code failed auth

### DIFF
--- a/handlers_test.go
+++ b/handlers_test.go
@@ -112,6 +112,11 @@ func TestLoginHandler(t *testing.T) {
 			Password:     "test",
 			ExpectedCode: http.StatusOK,
 		},
+		{
+			Username:     "test",
+			Password:     "notmypassword",
+			ExpectedCode: http.StatusUnauthorized,
+		},
 	}
 
 	for i, x := range cs {

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -76,6 +76,11 @@ Ka0WPQGKjQJhZRtqDAT3sfnrEEUa34+MkXQeKFCu6Yi0dRFic4iqOYU=
 -----END RSA PRIVATE KEY-----
 `
 
+const (
+	validUsername = "test"
+	validPassword = "test"
+)
+
 type fakeDiscoveryResponse struct {
 	AuthorizationEndpoint            string   `json:"authorization_endpoint"`
 	EndSessionEndpoint               string   `json:"end_session_endpoint"`
@@ -227,11 +232,18 @@ func (r *fakeOAuthServer) tokenHandler(cx *gin.Context) {
 			cx.AbortWithStatus(http.StatusBadRequest)
 			return
 		}
-		cx.JSON(http.StatusOK, tokenResponse{
-			IDToken:      token.Encode(),
-			AccessToken:  token.Encode(),
-			RefreshToken: token.Encode(),
-			ExpiresIn:    expiration.Second(),
+		if username == validUsername && password == validPassword {
+			cx.JSON(http.StatusOK, tokenResponse{
+				IDToken:      token.Encode(),
+				AccessToken:  token.Encode(),
+				RefreshToken: token.Encode(),
+				ExpiresIn:    expiration.Second(),
+			})
+			return
+		}
+		cx.JSON(http.StatusUnauthorized, gin.H{
+			"error":             "invalid_grant",
+			"error_description": "Invalid user credentials",
 		})
 	case oauth2.GrantTypeAuthCode:
 		cx.JSON(http.StatusOK, tokenResponse{


### PR DESCRIPTION
Now uses a response code of 401 for failed auths instead of 500