### PR TITLE
- updated the changelog with the changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+#### **1.2.9**
+
+BREAKING CHANGES:
+ * The login handler by default has been switched off, you must enable for --enable-login-handler
+ * The login handler now enforces the request can only come from a localhost if a client is defined 
+
 #### **1.2.8**
 
 FIXES:

--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ You can control the upstream endpoint via the --upstream-url option. Both http a
 * **/oauth/callback** is provider openid callback endpoint
 * **/oauth/expired** is a helper endpoint to check if a access token has expired, 200 for ok and, 401 for no token and 401 for expired
 * **/oauth/health** is the health checking endpoint for the proxy, you can also grab version from headers
-* **/oauth/login** provides a relay endpoint to login via grant_type=password i.e. POST /oauth/login form values are username=USERNAME&password=PASSWORD
+* **/oauth/login** provides a relay endpoint to login via grant_type=password i.e. POST /oauth/login form values are username=USERNAME&password=PASSWORD (must be enabled)
 * **/oauth/logout** provides a convenient endpoint to log the user out, it will always attempt to perform a back channel logout of offline tokens
 * **/oauth/token** is a helper endpoint which will display the current access token for you
 * **/oauth/metrics** is a prometheus metrics handler

--- a/cli.go
+++ b/cli.go
@@ -149,6 +149,10 @@ func getCLIOptions() []cli.Flag {
 			Value:  defaults.Upstream,
 			EnvVar: "PROXY_UPSTREAM_URL",
 		},
+		cli.BoolFlag{
+			Name:  "enable-login-handler",
+			Usage: "this enables the login hanlder /oauth/login, by default this is disabled",
+		},
 		cli.BoolTFlag{
 			Name:  "upstream-keepalives",
 			Usage: "enables or disables the keepalive connections for upstream endpoint",
@@ -414,6 +418,9 @@ func parseCLIOptions(cx *cli.Context, config *Config) (err error) {
 	}
 	if cx.IsSet("tls-client-certificate") {
 		config.TLSClientCertificate = cx.String("tls-client-certificate")
+	}
+	if cx.IsSet("enable-login-handler") {
+		config.EnableLoginHandler = cx.Bool("enable-login-handler")
 	}
 	if cx.IsSet("enable-metrics") {
 		config.EnableMetrics = cx.Bool("enable-metrics")

--- a/doc.go
+++ b/doc.go
@@ -34,6 +34,7 @@ const (
 	author      = "Rohith"
 	email       = "gambol99@gmail.com"
 	description = "is a proxy using the keycloak service for auth and authorization"
+	httpSchema  = "http"
 
 	headerUpgrade       = "Upgrade"
 	userContextName     = "identity"
@@ -130,6 +131,8 @@ type Config struct {
 	// LocalhostMetrics indicated the metrics can only be consume via localhost
 	LocalhostMetrics bool `json:"localhost-only-metrics" yaml:"localhost-only-metrics"`
 
+	// EnableLoginHandler indicates we want the login handler enabled
+	EnableLoginHandler bool `json:"enable-login-handler" yaml:"enable-login-handler"`
 	// EnableAuthorizationHeader indicates we should pass the authorization header
 	EnableAuthorizationHeader bool `json:"enable-authorization-header" yaml:"enable-authorization-header"`
 

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -85,6 +85,27 @@ func TestExpirationHandler(t *testing.T) {
 	}
 }
 
+func TestLoginHandlerDisabled(t *testing.T) {
+	config := newFakeKeycloakConfig()
+	config.EnableLoginHandler = false
+
+	_, _, url := newTestProxyService(config)
+	resp, err := http.Post(url+"/oauth/login", "", nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestLoginHandlerNotDisabled(t *testing.T) {
+	config := newFakeKeycloakConfig()
+	config.EnableLoginHandler = true
+	_, _, url := newTestProxyService(config)
+	resp, err := http.Post(url+"/oauth/login", "", nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
 func TestLoginHandler(t *testing.T) {
 	_, _, u := newTestProxyService(nil)
 

--- a/server.go
+++ b/server.go
@@ -177,7 +177,10 @@ func (r *oauthProxy) createReverseProxy() error {
 	oauth.GET(tokenURL, r.tokenHandler)
 	oauth.GET(expiredURL, r.expirationHandler)
 	oauth.GET(logoutURL, r.logoutHandler)
-	oauth.POST(loginURL, r.loginHandler)
+	// step: is the login hanler enabled?
+	if r.config.EnableLoginHandler {
+		oauth.POST(loginURL, r.loginHandler)
+	}
 	// step: enable the metric page?
 	if r.config.EnableMetrics {
 		oauth.GET(metricsURL, r.metricsHandler)
@@ -242,8 +245,7 @@ func (r *oauthProxy) createForwardingProxy() error {
 	}
 
 	proxy.OnResponse().DoFunc(func(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
-		// @NOTES, somewhat annoying but goproxy hands back a nil response on proxy client
-		// errors
+		// @NOTES, somewhat annoying but goproxy hands back a nil response on proxy client errors
 		if resp != nil && r.config.LogRequests {
 			start := ctx.UserData.(time.Time)
 			latency := time.Now().Sub(start)

--- a/server_test.go
+++ b/server_test.go
@@ -135,6 +135,7 @@ func newFakeKeycloakConfig() *Config {
 		DiscoveryURL:              "127.0.0.1:8080",
 		EnableAuthorizationHeader: true,
 		EnableRefreshTokens:       false,
+		EnableLoginHandler:        true,
 		EncryptionKey:             "AgXa7xRcoClDEU0ZDSH4X0XhL5Qy2Z2j",
 		LogRequests:               true,
 		Scopes:                    []string{},

--- a/utils.go
+++ b/utils.go
@@ -309,7 +309,7 @@ func containsSubString(value string, list []string) bool {
 //
 func tryDialEndpoint(location *url.URL) (net.Conn, error) {
 	switch dialAddress := dialAddress(location); location.Scheme {
-	case "http":
+	case httpSchema:
 		return net.Dial("tcp", dialAddress)
 	default:
 		return tls.Dial("tcp", dialAddress, &tls.Config{
@@ -383,7 +383,7 @@ func dialAddress(location *url.URL) string {
 	items := strings.Split(location.Host, ":")
 	if len(items) != 2 {
 		switch location.Scheme {
-		case "http":
+		case httpSchema:
 			return location.Host + ":80"
 		default:
 			return location.Host + ":443"


### PR DESCRIPTION
- adding an extra option to enable the login handler, by default its disabled now
- ensuring the when enabling and we have a client secret, the request must come from localhost
- wrapping the code in a anonymouse method to reduce the repetitve logging statements
- added two test to check the login handler enable options
- added the http as a constant to fix the govetting