### PR TITLE
Refresh Token Encryption

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ script:
 - if ([[ ${TRAVIS_BRANCH} == "master" ]] && [[ ${TRAVIS_EVENT_TYPE} == "push" ]]); then
     go get github.com/mattn/goveralls;
     goveralls -service=travis-ci;
+    make bench;
   fi
 deploy:
   provider: releases


### PR DESCRIPTION
- fixing a bug with refresh tokens and access token encryption enabled
- the access needed to be encrypted, perhaps move this into a common method?