### PR TITLE
Resource Slashs

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -33,7 +33,6 @@ func (r *Resource) parse(resource string) (*Resource, error) {
 	if resource == "" {
 		return nil, errors.New("the resource has no options")
 	}
-	// parse the syntax
 	for _, x := range strings.Split(resource, "|") {
 		kp := strings.Split(x, "=")
 		if len(kp) != 2 {
@@ -42,6 +41,9 @@ func (r *Resource) parse(resource string) (*Resource, error) {
 		switch kp[0] {
 		case "uri":
 			r.URL = kp[1]
+			if !strings.HasPrefix(r.URL, "/") {
+				return nil, errors.New("the resource uri should start with a '/'")
+			}
 		case "methods":
 			r.Methods = strings.Split(kp[1], ",")
 			if len(r.Methods) == 1 {

--- a/resource_test.go
+++ b/resource_test.go
@@ -29,6 +29,7 @@ func TestDecodeResourceBad(t *testing.T) {
 		{Option: "unknown=bad"},
 		{Option: "uri=/|unknown=bad"},
 		{Option: "uri"},
+		{Option: "uri=hello"},
 		{Option: "uri=/|white-listed=ERROR"},
 	}
 	for i, c := range cs {


### PR DESCRIPTION
- we should inform the user that a prefix slash is required, rather than pemitting the error