### PR TITLE
Logging Issue

### DIFF
--- a/forwarding.go
+++ b/forwarding.go
@@ -61,7 +61,8 @@ func (r *oauthProxy) proxyMiddleware() echo.MiddlewareFunc {
 			cx.Request().Header.Set("X-Forwarded-Host", cx.Request().URL.Host)
 			cx.Request().Header.Set("X-Forwarded-Proto", cx.Request().Header.Get("X-Forwarded-Proto"))
 
-			r.upstream.ServeHTTP(cx.Response().Writer, cx.Request())
+			r.upstream.ServeHTTP(cx.Response(), cx.Request())
+
 			return nil
 		}
 	}


### PR DESCRIPTION
- fixed the logging issue, the ServeHTTP needs to be feed the Response interface not the underlining
  http.ResponseWriter in order to update the internal counters. Otherwise the request it fine, but the
  logging is not representative of the result.