### PR TITLE
use --no-cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL Name=keycloak-proxy \
       Url=https://github.com/gambol99/keycloak-proxy \
       Help=https://github.com/gambol99/keycloak-proxy/issues
 
-RUN apk add ca-certificates --update
+RUN apk add --no-cache ca-certificates
 
 ADD templates/ /opt/templates
 ADD bin/keycloak-proxy /opt/keycloak-proxy


### PR DESCRIPTION
--update isn't available in alpine 3.6 its better to use --no-cache this always downloads the latest index