### PR TITLE
Correct typo and added ENV Variable

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -143,9 +143,9 @@ type Config struct {
 	// EnableForwarding enables the forwarding proxy
 	EnableForwarding bool `json:"enable-forwarding" yaml:"enable-forwarding" usage:"enables the forwarding proxy mode, signing outbound request"`
 	// EnableSecurityFilter enabled the security handler
-	EnableSecurityFilter bool `json:"enable-security-filter" yaml:"enable-security-filter" usage:"enables the security filter handler"`
+	EnableSecurityFilter bool `json:"enable-security-filter" yaml:"enable-security-filter" usage:"enables the security filter handler" env:"ENABLE_SECURITY_FILTER"`
 	// EnableRefreshTokens indicate's you wish to ignore using refresh tokens and re-auth on expiration of access token
-	EnableRefreshTokens bool `json:"enable-refresh-tokens" yaml:"enable-refresh-tokens" usage:"nables the handling of the refresh tokens" env:"ENABLE_SECURITY_FILTER"`
+	EnableRefreshTokens bool `json:"enable-refresh-tokens" yaml:"enable-refresh-tokens" usage:"Enables the handling of the refresh tokens" env:"ENABLE_REFRESH_TOKEN"`
 	// EnableLoginHandler indicates we want the login handler enabled
 	EnableLoginHandler bool `json:"enable-login-handler" yaml:"enable-login-handler" usage:"enables the handling of the refresh tokens" env:"ENABLE_LOGIN_HANDLER"`
 	// EnableAuthorizationHeader indicates we should pass the authorization header


### PR DESCRIPTION
There is an copy and past error in the documentation. PROXY_ENABLE_SECURITY_FILTER is currently mapped to enable-refresh-tokens which is not correct this means that enable-refresh-tokens does not have an env variable so it was added.