### PR TITLE
Upstream Authorization Cookie

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,6 +31,7 @@ func newDefaultConfig() *Config {
 		CookieAccessName:            "kc-access",
 		CookieRefreshName:           "kc-state",
 		EnableAuthorizationHeader:   true,
+		EnableAuthorizationCookies:  true,
 		EnableTokenHeader:           true,
 		Headers:                     make(map[string]string),
 		LetsEncryptCacheDir:         "./cache/",

--- a/doc.go
+++ b/doc.go
@@ -151,7 +151,9 @@ type Config struct {
 	// EnableLoginHandler indicates we want the login handler enabled
 	EnableLoginHandler bool `json:"enable-login-handler" yaml:"enable-login-handler" usage:"enables the handling of the refresh tokens" env:"ENABLE_LOGIN_HANDLER"`
 	// EnableAuthorizationHeader indicates we should pass the authorization header
-	EnableAuthorizationHeader bool `json:"enable-authorization-header" yaml:"enable-authorization-header" usage:"adds the authorization header to the proxy request"`
+	EnableAuthorizationHeader bool `json:"enable-authorization-header" yaml:"enable-authorization-header" usage:"adds the authorization header to the proxy request" env:"ENABLE_AUTHORIZATION_HEADER"`
+	// EnableAuthorizationCookies indicates we should pass the authorization cookies to the upstream endpoint
+	EnableAuthorizationCookies bool `json:"enable-authorization-cookies" yaml:"enable-authorization-cookies" usage:"adds the authorization cookies to the uptream proxy request" env:"ENABLE_AUTHORIZATION_COOKIES"`
 	// EnableHTTPSRedirect indicate we should redirection http -> https
 	EnableHTTPSRedirect bool `json:"enable-https-redirection" yaml:"enable-https-redirection" usage:"enable the http to https redirection on the http service"`
 	// EnableProfiling indicates if profiles is switched on

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -288,19 +288,19 @@ func TestCallbackURL(t *testing.T) {
 		},
 		{
 			URI:              oauthURL + callbackURL + "?code=fake",
-			ExpectedCookies:  []string{cfg.CookieAccessName},
+			ExpectedCookies:  map[string]string{cfg.CookieAccessName: ""},
 			ExpectedLocation: "/",
 			ExpectedCode:     http.StatusTemporaryRedirect,
 		},
 		{
 			URI:              oauthURL + callbackURL + "?code=fake&state=/admin",
-			ExpectedCookies:  []string{cfg.CookieAccessName},
+			ExpectedCookies:  map[string]string{cfg.CookieAccessName: ""},
 			ExpectedLocation: "/",
 			ExpectedCode:     http.StatusTemporaryRedirect,
 		},
 		{
 			URI:              oauthURL + callbackURL + "?code=fake&state=L2FkbWlu",
-			ExpectedCookies:  []string{cfg.CookieAccessName},
+			ExpectedCookies:  map[string]string{cfg.CookieAccessName: ""},
 			ExpectedLocation: "/admin",
 			ExpectedCode:     http.StatusTemporaryRedirect,
 		},

--- a/middleware.go
+++ b/middleware.go
@@ -337,6 +337,11 @@ func (r *oauthProxy) headersMiddleware(custom []string) func(http.Handler) http.
 					req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", user.token.Encode()))
 				}
 
+				if !r.config.EnableAuthorizationCookies {
+					// @step: we can just overwrite the cookie
+					req.AddCookie(&http.Cookie{Name: r.config.CookieAccessName, Value: "censored"})
+					req.AddCookie(&http.Cookie{Name: r.config.CookieRefreshName, Value: "censored"})
+				}
 				// inject any custom claims
 				for claim, header := range customClaims {
 					if claim, found := user.claims[claim]; found {

--- a/server_test.go
+++ b/server_test.go
@@ -327,6 +327,25 @@ func TestAuthTokenHeaderDisabled(t *testing.T) {
 	p.RunTests(t, requests)
 }
 
+func TestDisableAuthorizationCookie(t *testing.T) {
+	c := newFakeKeycloakConfig()
+	c.EnableAuthorizationCookies = false
+	p := newFakeProxy(c)
+	token := newTestToken(p.idp.getLocation())
+	signed, _ := p.idp.signToken(token.claims)
+
+	requests := []fakeRequest{
+		{
+			URI:                     "/auth_all/test",
+			RawToken:                signed.Encode(),
+			ExpectedContentContains: "kc-access=censored; kc-state=censored",
+			ExpectedProxy:           true,
+			ExpectedCode:            http.StatusOK,
+		},
+	}
+	p.RunTests(t, requests)
+}
+
 func newTestService() string {
 	_, _, u := newTestProxyService(nil)
 	return u
@@ -375,19 +394,20 @@ func newFakeHTTPRequest(method, path string) *http.Request {
 
 func newFakeKeycloakConfig() *Config {
 	return &Config{
-		ClientID:                  fakeClientID,
-		ClientSecret:              fakeSecret,
-		CookieAccessName:          "kc-access",
-		CookieRefreshName:         "kc-state",
-		DisableAllLogging:         true,
-		DiscoveryURL:              "127.0.0.1:0",
-		EnableAuthorizationHeader: true,
-		EnableLogging:             false,
-		EnableLoginHandler:        true,
-		EnableTokenHeader:         true,
-		Listen:                    "127.0.0.1:0",
-		Scopes:                    []string{},
-		Verbose:                   true,
+		ClientID:                   fakeClientID,
+		ClientSecret:               fakeSecret,
+		CookieAccessName:           "kc-access",
+		CookieRefreshName:          "kc-state",
+		DisableAllLogging:          true,
+		DiscoveryURL:               "127.0.0.1:0",
+		EnableAuthorizationHeader:  true,
+		EnableAuthorizationCookies: true,
+		EnableLogging:              false,
+		EnableLoginHandler:         true,
+		EnableTokenHeader:          true,
+		Listen:                     "127.0.0.1:0",
+		Scopes:                     []string{},
+		Verbose:                    true,
 		Resources: []*Resource{
 			{
 				URL:     fakeAdminRoleURL,


### PR DESCRIPTION
- adding an option to stop the proxy from including the authorization cookies in the upstream request

so disabling all authorization tokens would mean specifying `--enable-authorization-cookies=false --enable-authorization-header=false --enable-token-header=false` .. 

TODO: add shortcut to disable all threw
