### PR TITLE
Upstream Authorization Cookie

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,6 +31,7 @@ func newDefaultConfig() *Config {
 		CookieAccessName:            "kc-access",
 		CookieRefreshName:           "kc-state",
 		EnableAuthorizationHeader:   true,
+		EnableAuthorizationCookies:  true,
 		EnableTokenHeader:           true,
 		Headers:                     make(map[string]string),
 		LetsEncryptCacheDir:         "./cache/",

--- a/doc.go
+++ b/doc.go
@@ -134,8 +134,6 @@ type Config struct {
 	// Headers permits adding customs headers across the board
 	Headers map[string]string `json:"headers" yaml:"headers" usage:"custom headers to the upstream request, key=value"`
 
-	// EnableTokenHeader adds the JWT token to the upstream authentication headers
-	EnableTokenHeader bool `json:"enable-token-header" yaml:"enable-token-header" usage:"enables the token authentication header X-Auth-Token to upstream"`
 	// EnableEncryptedToken indicates the access token should be encoded
 	EnableEncryptedToken bool `json:"enable-encrypted-token" yaml:"enable-encrypted-token" usage:"enable encryption for the access tokens"`
 	// EnableLogging indicates if we should log all the requests
@@ -150,8 +148,12 @@ type Config struct {
 	EnableRefreshTokens bool `json:"enable-refresh-tokens" yaml:"enable-refresh-tokens" usage:"enables the handling of the refresh tokens" env:"ENABLE_REFRESH_TOKEN"`
 	// EnableLoginHandler indicates we want the login handler enabled
 	EnableLoginHandler bool `json:"enable-login-handler" yaml:"enable-login-handler" usage:"enables the handling of the refresh tokens" env:"ENABLE_LOGIN_HANDLER"`
+	// EnableTokenHeader adds the JWT token to the upstream authentication headers
+	EnableTokenHeader bool `json:"enable-token-header" yaml:"enable-token-header" usage:"enables the token authentication header X-Auth-Token to upstream"`
 	// EnableAuthorizationHeader indicates we should pass the authorization header
-	EnableAuthorizationHeader bool `json:"enable-authorization-header" yaml:"enable-authorization-header" usage:"adds the authorization header to the proxy request"`
+	EnableAuthorizationHeader bool `json:"enable-authorization-header" yaml:"enable-authorization-header" usage:"adds the authorization header to the proxy request" env:"ENABLE_AUTHORIZATION_HEADER"`
+	// EnableAuthorizationCookies indicates we should pass the authorization cookies to the upstream endpoint
+	EnableAuthorizationCookies bool `json:"enable-authorization-cookies" yaml:"enable-authorization-cookies" usage:"adds the authorization cookies to the uptream proxy request" env:"ENABLE_AUTHORIZATION_COOKIES"`
 	// EnableHTTPSRedirect indicate we should redirection http -> https
 	EnableHTTPSRedirect bool `json:"enable-https-redirection" yaml:"enable-https-redirection" usage:"enable the http to https redirection on the http service"`
 	// EnableProfiling indicates if profiles is switched on

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -288,19 +288,19 @@ func TestCallbackURL(t *testing.T) {
 		},
 		{
 			URI:              oauthURL + callbackURL + "?code=fake",
-			ExpectedCookies:  []string{cfg.CookieAccessName},
+			ExpectedCookies:  map[string]string{cfg.CookieAccessName: ""},
 			ExpectedLocation: "/",
 			ExpectedCode:     http.StatusTemporaryRedirect,
 		},
 		{
 			URI:              oauthURL + callbackURL + "?code=fake&state=/admin",
-			ExpectedCookies:  []string{cfg.CookieAccessName},
+			ExpectedCookies:  map[string]string{cfg.CookieAccessName: ""},
 			ExpectedLocation: "/",
 			ExpectedCode:     http.StatusTemporaryRedirect,
 		},
 		{
 			URI:              oauthURL + callbackURL + "?code=fake&state=L2FkbWlu",
-			ExpectedCookies:  []string{cfg.CookieAccessName},
+			ExpectedCookies:  map[string]string{cfg.CookieAccessName: ""},
 			ExpectedLocation: "/admin",
 			ExpectedCode:     http.StatusTemporaryRedirect,
 		},

--- a/misc.go
+++ b/misc.go
@@ -27,6 +27,32 @@ import (
 	"go.uber.org/zap"
 )
 
+// filterCookies is responsible for censoring any cookies we don't want sent
+func filterCookies(req *http.Request, filter []string) error {
+	// @NOTE: there doesn't appear to be a way of removing a cookie from the http.Request as
+	// AddCookie() just append
+	cookies := req.Cookies()
+	// @step: empty the current cookies
+	req.Header.Set("Cookie", "")
+	// @step: iterate the cookies and filter out anything we
+	for _, x := range cookies {
+		var found bool
+		// @step: does this cookie match our filter?
+		for _, n := range filter {
+			if x.Name == n {
+				req.AddCookie(&http.Cookie{Name: x.Name, Value: "censored"})
+				found = true
+				break
+			}
+		}
+		if !found {
+			req.AddCookie(x)
+		}
+	}
+
+	return nil
+}
+
 // revokeProxy is responsible to stopping the middleware from proxying the request
 func (r *oauthProxy) revokeProxy(w http.ResponseWriter, req *http.Request) context.Context {
 	var scope *RequestScope


### PR DESCRIPTION
- adding an option to stop the proxy from including the authorization cookies in the upstream request

so disabling all authorization tokens would mean specifying `--enable-authorization-cookies=false --enable-authorization-header=false --enable-token-header=false` ..

TODO: add shortcut to disable all three

```shell
$ bin/keycloak-proxy --config config.yml --enable-authorization-cookies=false --enable-authorization-header=false --enable-token-header=false
...
[jest@starfury keycloak-proxy]$ nc -l 127.0.0.1 8080
GET / HTTP/1.1
Host: 127.0.0.1:8080
User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 Safari/537.36
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8
Accept-Language: en-US,en;q=0.9
Cache-Control: max-age=0
Cookie: event_filter=merged; seen_cookie_message=yes; sidebar_collapsed=false; kc-access=censored
Upgrade-Insecure-Requests: 1
X-Auth-Email: gambol99@gmail.com
gambol99@gmail.com
X-Auth-Expiresin: 2017-11-18 16:50:12 +0000 UTC
X-Auth-Family-Name: Jayawardene
X-Auth-Given-Name: Rohith
X-Auth-Name: Rohith Jayawardene
X-Auth-Roles: broker:uma_protection,broker:admin-user,broker:devops-user
X-Auth-Subject: ID
X-Auth-Userid: gambol99@gmail.com
X-Auth-Username: gambol99@gmail.com
X-Forwarded-For: 127.0.0.1
X-Forwarded-Host: 127.0.0.1:8080
X-Forwarded-Proto: 
Accept-Encoding: gzip
Connection: close
```