### PR TITLE
Groups Claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+
+#### **2.1.1 (Unreleased)**
+
+FEATURES:
+* Added the groups parameter to the resource, permitting users to use the `groups` claim in the token [#PR301](https://github.com/gambol99/keycloak-proxy/pull/301)
+
 #### **2.1.0**
 
 FIXES:

--- a/README.md
+++ b/README.md
@@ -211,6 +211,9 @@ resources:
   roles:
   - client:test1
   - client:test2
+  groups:
+  - admins
+  - users
 - uri: /backend*
   roles:
   - client:test1
@@ -357,6 +360,7 @@ On protected resources the upstream endpoint will receive a number of headers ad
 id := user.(*userContext)
 cx.Request().Header.Set("X-Auth-Email", id.email)
 cx.Request().Header.Set("X-Auth-ExpiresIn", id.expiresAt.String())
+cx.Request().Header.Set("X-Auth-Groups", strings.Join(id.groups, ","))
 cx.Request().Header.Set("X-Auth-Roles", strings.Join(id.roles, ","))
 cx.Request().Header.Set("X-Auth-Subject", id.id)
 cx.Request().Header.Set("X-Auth-Token", id.token.Encode())
@@ -432,6 +436,28 @@ Another example would be limiting the email domain permitted; say you have some 
 match-claims:
   email: ^.*@example.com$
 ```
+
+#### **Groups Claims**
+
+You can match on the group claims within a token via the `groups` parameter available within the resource. Note while roles are implicitly required i.e. `roles=admin,user` the user MUST have roles 'admin' AND 'user', groups are applied with an OR operation, so `groups=users,testers` requires the user MUST be within 'users' OR 'testers'. At present the claim name is hardcoded to `groups` i.e a JWT token would look like the below.
+
+```JSON
+{
+  "iss": "https://sso.example.com",
+  "sub": "",
+  "aud": "test",
+  "exp": 1515269245,
+  "iat": 1515182845,
+  "email": "gambol99@gmail.com",
+  "groups": [
+    "group_one",
+    "group_two"
+  ],
+  "name": "Rohith"
+}
+```
+
+Note: I'm also considering changing the way groups are implemented, exchanging for how match-claims are done, such as `--match=[]groups=(a|b|c)` but would mean adding matches to URI resource first.
 
 #### **Custom Pages**
 

--- a/doc.go
+++ b/doc.go
@@ -56,11 +56,12 @@ const (
 	tokenURL         = "/token"
 	debugURL         = "/debug/pprof"
 
-	claimPreferredName  = "preferred_username"
 	claimAudience       = "aud"
-	claimResourceAccess = "resource_access"
+	claimPreferredName  = "preferred_username"
 	claimRealmAccess    = "realm_access"
+	claimResourceAccess = "resource_access"
 	claimResourceRoles  = "roles"
+	claimGroups         = "groups"
 )
 
 const (
@@ -99,6 +100,8 @@ type Resource struct {
 	WhiteListed bool `json:"white-listed" yaml:"white-listed"`
 	// Roles the roles required to access this url
 	Roles []string `json:"roles" yaml:"roles"`
+	// Groups is a list of groups the user is in
+	Groups []string `json:"groups" yaml:"groups"`
 }
 
 // Config is the configuration for the proxy
@@ -316,28 +319,30 @@ type reverseProxy interface {
 	ServeHTTP(rw http.ResponseWriter, req *http.Request)
 }
 
-// userContext represents a user
+// userContext holds the information extracted the token
 type userContext struct {
 	// the id of the user
 	id string
-	// the email associated to the user
-	email string
-	// a name of the user
-	name string
-	// the preferred name
-	preferredName string
-	// the expiration of the access token
-	expiresAt time.Time
-	// a set of roles associated
-	roles []string
 	// the audience for the token
 	audience string
-	// the access token itself
-	token jose.JWT
-	// the claims associated to the token
-	claims jose.Claims
 	// whether the context is from a session cookie or authorization header
 	bearerToken bool
+	// the claims associated to the token
+	claims jose.Claims
+	// the email associated to the user
+	email string
+	// the expiration of the access token
+	expiresAt time.Time
+	// groups is a collection of groups the user in in
+	groups []string
+	// a name of the user
+	name string
+	// preferredName is the name of the user
+	preferredName string
+	// roles is a collection of roles the users holds
+	roles []string
+	// the access token itself
+	token jose.JWT
 }
 
 // tokenResponse

--- a/resource.go
+++ b/resource.go
@@ -53,6 +53,8 @@ func (r *Resource) parse(resource string) (*Resource, error) {
 			}
 		case "roles":
 			r.Roles = strings.Split(kp[1], ",")
+		case "groups":
+			r.Groups = strings.Split(kp[1], ",")
 		case "white-listed":
 			value, err := strconv.ParseBool(kp[1])
 			if err != nil {

--- a/resource_test.go
+++ b/resource_test.go
@@ -72,6 +72,14 @@ func TestResourceParseOk(t *testing.T) {
 			Option:   "uri=/*|methods=any",
 			Resource: &Resource{URL: "/*", Methods: allHTTPMethods},
 		},
+		{
+			Option:   "uri=/*|groups=admin,test",
+			Resource: &Resource{URL: "/*", Methods: allHTTPMethods, Groups: []string{"admin", "test"}},
+		},
+		{
+			Option:   "uri=/*|groups=admin",
+			Resource: &Resource{URL: "/*", Methods: allHTTPMethods, Groups: []string{"admin"}},
+		},
 	}
 	for i, x := range cs {
 		r, err := newResource().parse(x.Option)

--- a/server_test.go
+++ b/server_test.go
@@ -529,6 +529,11 @@ func (t *fakeToken) setExpiration(tm time.Time) {
 	t.claims.Add("exp", float64(tm.Unix()))
 }
 
+// addGroups adds groups to then token
+func (t *fakeToken) addGroups(groups []string) {
+	t.claims.Add("groups", groups)
+}
+
 // addRealmRoles adds realms roles to token
 func (t *fakeToken) addRealmRoles(roles []string) {
 	t.claims.Add("realm_access", map[string]interface{}{

--- a/utils.go
+++ b/utils.go
@@ -187,15 +187,29 @@ func fileExists(filename string) bool {
 	return true
 }
 
-// hasRoles checks the scopes are the same
-func hasRoles(required, issued []string) bool {
-	for _, role := range required {
-		if !containedIn(role, issued) {
-			return false
+// hasAccess checks we have all or any of the needed items in the list
+func hasAccess(need, have []string, all bool) bool {
+	if len(need) == 0 {
+		return true
+	}
+
+	var matched int
+	for _, x := range need {
+		found := containedIn(x, have)
+		switch found {
+		case true:
+			if !all {
+				return true
+			}
+			matched++
+		default:
+			if all {
+				return false
+			}
 		}
 	}
 
-	return true
+	return matched > 0
 }
 
 // containedIn checks if a value in a list of a strings

--- a/utils_test.go
+++ b/utils_test.go
@@ -225,32 +225,91 @@ func TestDecryptDataBlock(t *testing.T) {
 
 }
 
-func TestHasRoles(t *testing.T) {
-	testCases := []struct {
-		Roles    []string
-		Required []string
-		Ok       bool
+func TestHasAccessOK(t *testing.T) {
+	cs := []struct {
+		Have     []string
+		Need     []string
+		Required bool
+	}{
+		{},
+		{
+			Have: []string{"a", "b"},
+		},
+		{
+			Have:     []string{"a", "b", "c"},
+			Need:     []string{"a", "b"},
+			Required: true,
+		},
+		{
+			Have: []string{"a", "b", "c"},
+			Need: []string{"a", "c"},
+		},
+		{
+			Have: []string{"a", "b", "c"},
+			Need: []string{"c"},
+		},
+		{
+			Have: []string{"a", "b", "c"},
+			Need: []string{"b"},
+		},
+		{
+			Have: []string{"a", "b", "c"},
+			Need: []string{"b"},
+		},
+		{
+			Have: []string{"a", "b"},
+			Need: []string{"a"},
+		},
+		{
+			Have:     []string{"a", "b"},
+			Need:     []string{"a"},
+			Required: true,
+		},
+		{
+			Have:     []string{"b", "a"},
+			Need:     []string{"a"},
+			Required: true,
+		},
+	}
+	for i, x := range cs {
+		assert.True(t, hasAccess(x.Need, x.Have, x.Required), "case: %d should be true, have: %v, need: %v, require: %t ", i, x.Have, x.Need, x.Required)
+	}
+}
+
+func TestHasAccessBad(t *testing.T) {
+	cs := []struct {
+		Have     []string
+		Need     []string
+		Required bool
 	}{
 		{
-			Roles:    []string{"a", "b", "c"},
-			Required: []string{"a", "b"},
-			Ok:       true,
+			Have: []string{"a", "b"},
+			Need: []string{"c"},
 		},
 		{
-			Roles:    []string{"a", "b"},
-			Required: []string{"a", "b"},
-			Ok:       true,
+			Have:     []string{"a", "b"},
+			Need:     []string{"c"},
+			Required: true,
 		},
 		{
-			Roles:    []string{"a", "b", "c"},
-			Required: []string{"a", "d"},
+			Have:     []string{"a", "c"},
+			Need:     []string{"a", "b"},
+			Required: true,
+		},
+		{
+			Have:     []string{"a", "b", "c"},
+			Need:     []string{"b", "j"},
+			Required: true,
+		},
+		{
+			Have:     []string{"a", "b", "c"},
+			Need:     []string{"a", "d"},
+			Required: true,
 		},
 	}
 
-	for i, test := range testCases {
-		if !hasRoles(test.Required, test.Roles) && test.Ok {
-			assert.Fail(t, "test case: %i should have ok, %s, %s", i, test.Roles, test.Required)
-		}
+	for i, x := range cs {
+		assert.False(t, hasAccess(x.Need, x.Have, x.Required), "case: %d should be false, have: %v, need: %v, require: %t ", i, x.Have, x.Need, x.Required)
 	}
 }
 


### PR DESCRIPTION
The current implementation does not take into account the standard `groups` claim when matching on the resource. This PR add the ability to add an additional field `--groups=list,of,groups` to the resource.

Note unlike the roles which are applied with an AND operation a user simply has to exist in one of the groups specified.
  