### PR TITLE
Websocket Fix

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -51,7 +51,7 @@ func entrypointMiddleware(next http.Handler) http.Handler {
 
 		// continue the flow
 		scope := &RequestScope{}
-		resp := middleware.NewWrapResponseWriter(w, 2)
+		resp := middleware.NewWrapResponseWriter(w, 1)
 		next.ServeHTTP(resp, req.WithContext(context.WithValue(req.Context(), contextScopeName, scope)))
 
 		// place back the original uri for proxying request


### PR DESCRIPTION
The http2FancyWriter does not implement the http.Hijacker method causing the websocket upgrade to throw an exception. This PR fixes the issues by forcing the selection of httpFancyWriter{}