### PR TITLE
Release v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 
-#### **2.1.1 (Unreleased)**
+#### **2.1.1**
 
 FEATURES:
 * Added the groups parameter to the resource, permitting users to use the `groups` claim in the token [#PR301](https://github.com/gambol99/keycloak-proxy/pull/301)
+* Removed the authors file [#PR299](https://github.com/gambol99/keycloak-proxy/pull/299)
+
+FIXES:
+* Fixed the custom headers when upgrading to websockets [#PR311](https://github.com/gambol99/keycloak-proxy/pull/311)
+* Fixed exception when upgrading to websockets [#PR303](https://github.com/gambol99/keycloak-proxy/pull/303)
 
 #### **2.1.0**
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ USAGE:
    keycloak-proxy [options]
 
 VERSION:
-   v2.1.0 (git+sha: 87f0b9c-dirty, built: 21-12-2017)
+   v2.1.1 (git+sha: e92c9b2-dirty, built: 12-02-2018)
 
 AUTHOR:
    Rohith <gambol99@gmail.com>

--- a/doc.go
+++ b/doc.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	release  = "v2.1.0"
+	release  = "v2.1.1"
 	gitsha   = "no gitsha provided"
 	compiled = "0"
 	version  = ""


### PR DESCRIPTION
FEATURES:
* Added the groups parameter to the resource, permitting users to use the jest docker ecryptfs dev claim in the token [#PR301](https://github.com/gambol99/keycloak-proxy/pull/301)
* Removed the authors file [#PR299](https://github.com/gambol99/keycloak-proxy/pull/299)

FIXES:
* Fixed the custom headers when upgrading to websockets [#PR311](https://github.com/gambol99/keycloak-proxy/pull/311)
* Fixed exception when upgrading to websockets [#PR303](https://github.com/gambol99/keycloak-proxy/pull/303)