### PR TITLE
Client Audience Header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ FEATURES:
 * Updated the docker base image alpine 3.7 [#PR313](https://github.com/gambol99/keycloak-proxy/pull/313)
 * Added the ability to control the timeout on the initial openid configuration from .well-known/openid-configuration [#PR315](https://github.com/gambol99/keycloak-proxy/pull/315)
 * Updated to Golang version 1.10 [#PR316](https://github.com/gambol99/keycloak-proxy/pull/316)
+* Added the X-Auth-Audience to the upstream headers [#PR319](https://github.com/gambol99/keycloak-proxy/pull/319)
 
 #### **2.1.1**
 

--- a/middleware.go
+++ b/middleware.go
@@ -334,6 +334,7 @@ func (r *oauthProxy) headersMiddleware(custom []string) func(http.Handler) http.
 			scope := req.Context().Value(contextScopeName).(*RequestScope)
 			if scope.Identity != nil {
 				user := scope.Identity
+				req.Header.Set("X-Auth-Audience", user.audience)
 				req.Header.Set("X-Auth-Email", user.email)
 				req.Header.Set("X-Auth-ExpiresIn", user.expiresAt.String())
 				req.Header.Set("X-Auth-Groups", strings.Join(user.groups, ","))

--- a/server_test.go
+++ b/server_test.go
@@ -147,6 +147,24 @@ func TestForbiddenTemplate(t *testing.T) {
 	newFakeProxy(cfg).RunTests(t, requests)
 }
 
+func TestAudienceHeader(t *testing.T) {
+	c := newFakeKeycloakConfig()
+	c.NoRedirects = false
+	requests := []fakeRequest{
+		{
+			URI:           "/auth_all/test",
+			HasLogin:      true,
+			ExpectedProxy: true,
+			Redirects:     true,
+			ExpectedProxyHeaders: map[string]string{
+				"X-Auth-Audience": "test",
+			},
+			ExpectedCode: http.StatusOK,
+		},
+	}
+	newFakeProxy(c).RunTests(t, requests)
+}
+
 func TestAuthorizationTemplate(t *testing.T) {
 	cfg := newFakeKeycloakConfig()
 	cfg.SignInPage = "templates/sign_in.html.tmpl"


### PR DESCRIPTION
- adding the X-Auth-Audience header the to the upstream endpoint
- adding a the unit test to ensure it