### PR TITLE
Actually put forwarded host in X-Forwarded-Host

### DIFF
--- a/forwarding.go
+++ b/forwarding.go
@@ -39,6 +39,11 @@ func (r *oauthProxy) proxyMiddleware(next http.Handler) http.Handler {
 			}
 		}
 
+		// @step: add the proxy forwarding headers
+		req.Header.Add("X-Forwarded-For", realIP(req))
+		req.Header.Set("X-Forwarded-Host", req.URL.Host)
+		req.Header.Set("X-Forwarded-Proto", req.Header.Get("X-Forwarded-Proto"))
+
 		// @step: add any custom headers to the request
 		for k, v := range r.config.Headers {
 			req.Header.Set(k, v)
@@ -53,11 +58,6 @@ func (r *oauthProxy) proxyMiddleware(next http.Handler) http.Handler {
 		} else {
 			req.Host = r.endpoint.Host
 		}
-
-		// @step: add the proxy forwarding headers
-		req.Header.Add("X-Forwarded-For", realIP(req))
-		req.Header.Set("X-Forwarded-Host", req.URL.Host)
-		req.Header.Set("X-Forwarded-Proto", req.Header.Get("X-Forwarded-Proto"))
 
 		if isUpgradedConnection(req) {
 			r.log.Debug("upgrading the connnection", zap.String("client_ip", req.RemoteAddr))


### PR DESCRIPTION
Currently, the `X-Forwarded-Host` header sent upstream is the same as the `Host:` header sent upstream.  This is incorrect; it should be the incoming `Host:` value.  So this PR moves the `X-Forwarded-` header settings to a point *before* the incoming request is modified, making their default values be the ones from the original request, rather than ones modified by the custom headers or endpoint host value.