### PR TITLE
Don't infinite-redirect when https is proxied

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -361,6 +361,7 @@ func (r *oauthProxy) securityMiddleware(next http.Handler) http.Handler {
 		ContentTypeNosniff:    r.config.EnableContentNoSniff,
 		FrameDeny:             r.config.EnableFrameDeny,
 		SSLRedirect:           r.config.EnableHTTPSRedirect,
+		SSLProxyHeaders:       map[string]string{"X-Forwarded-Proto": "https"},
 	})
 
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
If you're behind an ingress server that provides the https, keycloak-proxy continually redirects to itself (when using `--enable-https-redirection` and `--enable-security-filter`), because it doesn't recognize `X-Forwarded-Proto: https` as meaning not to redirect.  Adding this line (copied from [unrolled/secure](github.com/unrolled/secure)'s README) to the options passed to `secure.New()` in `securityMiddleware` in `middleware.go` fixed the problem for me:

```go
SSLProxyHeaders:       map[string]string{"X-Forwarded-Proto": "https"},
```
