### PR TITLE
Dependency Update (go-oidc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ FEATURES:
 
 FIXES:
 * Fixed a redirection bug [#PR337](https://github.com/gambol99/keycloak-proxy/pull/337)
+* Updated the go-oidc to fix the cache header [issues](https://github.com/gambol99/keycloak-proxy/issues/340)[#PR339](https://github.com/gambol99/keycloak-proxy/pull/339)
 
 #### **2.1.1**
 

--- a/glide.lock
+++ b/glide.lock
@@ -18,7 +18,7 @@ imports:
 - name: github.com/fsnotify/fsnotify
   version: fd9ec7deca8bf46ecd2a795baaacf2b3a9be1197
 - name: github.com/gambol99/go-oidc
-  version: 2111f98a1397a35f1800f4c3c354a7abebbef75c
+  version: 87948fe50989333a6a3f970e48f8dec844361fa1
   subpackages:
   - http
   - jose


### PR DESCRIPTION
- updating the dependency for go-oidc which includes the fixed to http cache headers