### PR TITLE
Make use of go-oidc from the upstream

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f6bf634e96842367a387aa5cc9bfadc78ea32060c513c04ae050412f205a2ddb
-updated: 2017-07-11T17:24:26.212477004+02:00
+hash: 5c349144edb6cca474915fc8e59f97541694d351da4b7f777082cbcfa4383d1c
+updated: 2018-04-20T17:17:53.783165567-03:00
 imports:
 - name: github.com/armon/go-proxyproto
   version: 609d6338d3a76ec26ac3fe7045a164d9a58436e7
@@ -9,6 +9,12 @@ imports:
   - quantile
 - name: github.com/boltdb/bolt
   version: 144418e1475d8bf7abbdc48583500f1a20c62ea7
+- name: github.com/coreos/go-oidc
+  version: 1180514eaf4d9f38d0d19eef639a1d695e066e72
+  subpackages:
+  - jose
+  - oauth2
+  - oidc
 - name: github.com/coreos/pkg
   version: 447b7ec906e523386d9c53be15b55a8ae86ea944
   subpackages:
@@ -72,7 +78,7 @@ imports:
 - name: github.com/urfave/cli
   version: 0bdeddeeb0f650497d603c4ad7b20cfe685682f6
 - name: go.uber.org/atomic
-  version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
+  version: 8474b86a5a6f79c443ce4b2992817ff32cf208b8
 - name: go.uber.org/zap
   version: 54371c67da1bc746325e5582e48521a5db5d64ca
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,7 +4,7 @@ import:
 - package: github.com/armon/go-proxyproto
 - package: github.com/boltdb/bolt
 - package: github.com/fsnotify/fsnotify
-- package: github.com/gambol99/go-oidc
+- package: github.com/coreos/go-oidc
   subpackages:
   - jose
   - oauth2


### PR DESCRIPTION
Would be nice if possible to use `go-oidc` from the upstream repository.
I can see several benefits:

* Avoid the burden keep up to date with the upstream
* Get the latest bug fixes from the commiters
* Prevent duplicated effort

I ran all the tests and they seem to be fine. Also, if there's anything which you would like to see in the upstream let me know, and I can try to talk with the authors and get these changes in.