### PR TITLE
Remove unused getUserInfo

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -16,11 +16,6 @@ limitations under the License.
 package main
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io/ioutil"
-	"net/http"
 	"strings"
 	"time"
 
@@ -81,33 +76,6 @@ func getRefreshedToken(client *oidc.Client, t string) (jose.JWT, time.Time, erro
 // exchangeAuthenticationCode exchanges the authentication code with the oauth server for a access token
 func exchangeAuthenticationCode(client *oauth2.Client, code string) (oauth2.TokenResponse, error) {
 	return getToken(client, oauth2.GrantTypeAuthCode, code)
-}
-
-// getUserinfo is responsible for getting the userinfo from the IDPD
-func getUserinfo(client *oauth2.Client, endpoint string, token string) (jose.Claims, error) {
-	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set(authorizationHeader, fmt.Sprintf("Bearer %s", token))
-
-	resp, err := client.HttpClient().Do(req)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, errors.New("token not validate by userinfo endpoint")
-	}
-	content, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	var claims jose.Claims
-	if err := json.Unmarshal(content, &claims); err != nil {
-		return nil, err
-	}
-
-	return claims, nil
 }
 
 // getToken retrieves a code from the provider, extracts and verified the token

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gambol99/go-oidc/oauth2"
 	"github.com/pressly/chi"
 	"github.com/pressly/chi/middleware"
-	"github.com/stretchr/testify/assert"
 )
 
 type fakeAuthServer struct {
@@ -273,15 +272,6 @@ func (r *fakeAuthServer) tokenHandler(w http.ResponseWriter, req *http.Request) 
 	default:
 		w.WriteHeader(http.StatusBadRequest)
 	}
-}
-
-func TestGetUserinfo(t *testing.T) {
-	px, idp, _ := newTestProxyService(nil)
-	token := newTestToken(idp.getLocation()).getToken()
-	client, _ := px.client.OAuthClient()
-	claims, err := getUserinfo(client, px.idp.UserInfoEndpoint.String(), token.Encode())
-	assert.NoError(t, err)
-	assert.NotEmpty(t, claims)
 }
 
 func TestTokenExpired(t *testing.T) {


### PR DESCRIPTION
@gambol99 I could not find any usage to `getUserinfo` inside the codebase. Do you think we can remove it?