### PR TITLE
fix cookie expiration issue when exp claim is zero

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -116,7 +116,10 @@ func (r *oauthProxy) getAccessCookieExpiration(token jose.JWT, refresh string) t
 	// refresh token
 	duration := r.config.AccessTokenDuration
 	if _, ident, err := parseToken(refresh); err == nil {
-		duration = time.Until(ident.ExpiresAt)
+		delta := time.Until(ident.ExpiresAt)
+		if delta > 0 {
+			duration = delta
+		}
 	}
 
 	return duration


### PR DESCRIPTION
Hi,

Thanks for your excellent work!

I've encountered an issue with an infinite redirect loop after authentication which I tracked down to being caused by session cookies having 1970-01-01T00:00:00Z expiration dates.
After more digging, this was caused by the refresh token emitted by Keycloak which had a "exp" claim set to zero!

{
  "jti": "f6bdb3b4-409f-43d1-9675-24ab06404c9a",
  "exp": 0,
  "nbf": 0,
  "iat": 1525834984,
  "iss": "https://example.com/auth/realms/hello",
  "aud": "kubernetes",
  "sub": "a7c5ce69-657e-45a2-9904-3cb85d51be36",
  "typ": "Offline",
  "azp": "kubernetes",
  "nonce": "35e9f093d45483d1857c2e82c81fee51",
  "auth_time": 0,
  "session_state": "ba2e7a6f-985d-4647-b497-cb6e05809e3d",
  "realm_access": {
    "roles": [
      "offline_access",
      "uma_authorization"
    ]
  },
  "resource_access": {
    "account": {
      "roles": [
        "manage-account",
        "manage-account-links",
        "view-profile"
      ]
    }
  }
}

Then the time difference time.Until(ident.ExpiresAt) was producing a negative duration, which caused the cookie to be in the 70', which of course prevented the browser from keeping it, thus causing the infinite loop.

Hope this helps,

Morgan