### PR TITLE
Migration to golang/x/oauth2

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: c1c869f5b725bd212bddce15aeb6e436f0bdb9a4ec41b08842a79ce54f18f578
-updated: 2018-05-25T15:52:26.57095014+01:00
+hash: f2205edbf0530db6b2a560e450db24c7ceac943400a4258001b4c9a99aefeda5
+updated: 2018-05-28T14:02:51.337129882-03:00
 imports:
 - name: github.com/armon/go-proxyproto
   version: 609d6338d3a76ec26ac3fe7045a164d9a58436e7
@@ -92,8 +92,14 @@ imports:
 - name: golang.org/x/net
   version: 1c05540f6879653db88113bc4a2b70aec4bd491f
   subpackages:
+  - context
+  - context/ctxhttp
   - idna
   - publicsuffix
+- name: golang.org/x/oauth2
+  version: 6881fee410a5daf86371371f9ad451b95e168b71
+  subpackages:
+  - internal
 - name: golang.org/x/sys
   version: 95c6576299259db960f6c5b9b69ea52422860fce
   subpackages:
@@ -106,6 +112,16 @@ imports:
   - unicode/bidi
   - unicode/norm
   - width
+- name: google.golang.org/appengine
+  version: 0a24098c0ec68416ec050f567f75df563d6b231e
+  subpackages:
+  - internal
+  - internal/base
+  - internal/datastore
+  - internal/log
+  - internal/remote_api
+  - internal/urlfetch
+  - urlfetch
 - name: gopkg.in/bsm/ratelimit.v1
   version: db14e161995a5177acef654cb0dd785e8ee8bc22
 - name: gopkg.in/redis.v4

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,8 +7,8 @@ import:
 - package: github.com/gambol99/go-oidc
   subpackages:
   - jose
-  - oauth2
   - oidc
+- package: golang.org/x/oauth2
 - package: github.com/go-chi/chi
   subpackages:
   - middleware

--- a/middleware.go
+++ b/middleware.go
@@ -154,7 +154,8 @@ func (r *oauthProxy) authenticationMiddleware(resource *Resource) func(http.Hand
 					}
 
 					// attempt to refresh the access token
-					token, exp, err := getRefreshedToken(r.client, refresh)
+					config := getOAuthConfig(r, r.getRedirectionURL(w, req))
+					token, exp, err := getRefreshedToken(config, refresh)
 					if err != nil {
 						switch err {
 						case ErrRefreshTokenExpired:

--- a/oauth.go
+++ b/oauth.go
@@ -16,32 +16,34 @@ limitations under the License.
 package main
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io/ioutil"
-	"net/http"
+	"context"
 	"strings"
 	"time"
 
 	"github.com/gambol99/go-oidc/jose"
-	"github.com/gambol99/go-oidc/oauth2"
 	"github.com/gambol99/go-oidc/oidc"
+
+	"golang.org/x/oauth2"
 )
 
-// getOAuthClient returns a oauth2 client from the openid client
-func (r *oauthProxy) getOAuthClient(redirectionURL string) (*oauth2.Client, error) {
-	return oauth2.NewClient(r.idpClient, oauth2.Config{
-		Credentials: oauth2.ClientCredentials{
-			ID:     r.config.ClientID,
-			Secret: r.config.ClientSecret,
+const (
+	GrantTypeAuthCode     = "authorization_code"
+	GrantTypeUserCreds    = "password"
+	GrantTypeRefreshToken = "refresh_token"
+)
+
+// getOAuthClient returns a oauth2 configuration from the openid client
+func getOAuthConfig(r *oauthProxy, redirectionURL string) *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     r.config.ClientID,
+		ClientSecret: r.config.ClientSecret,
+		RedirectURL:  redirectionURL,
+		Scopes:       append(r.config.Scopes, oidc.DefaultScope...),
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  r.idp.AuthEndpoint.String(),
+			TokenURL: r.idp.TokenEndpoint.String(),
 		},
-		AuthMethod:  oauth2.AuthMethodClientSecretBasic,
-		AuthURL:     r.idp.AuthEndpoint.String(),
-		RedirectURL: redirectionURL,
-		Scope:       append(r.config.Scopes, oidc.DefaultScope...),
-		TokenURL:    r.idp.TokenEndpoint.String(),
-	})
+	}
 }
 
 // verifyToken verify that the token in the user context is valid
@@ -57,12 +59,8 @@ func verifyToken(client *oidc.Client, token jose.JWT) error {
 }
 
 // getRefreshedToken attempts to refresh the access token, returning the parsed token and the time it expires or a error
-func getRefreshedToken(client *oidc.Client, t string) (jose.JWT, time.Time, error) {
-	cl, err := client.OAuthClient()
-	if err != nil {
-		return jose.JWT{}, time.Time{}, err
-	}
-	response, err := getToken(cl, oauth2.GrantTypeRefreshToken, t)
+func getRefreshedToken(config *oauth2.Config, t string) (jose.JWT, time.Time, error) {
+	response, err := getToken(config, GrantTypeRefreshToken, t)
 	if err != nil {
 		if strings.Contains(err.Error(), "token expired") {
 			return jose.JWT{}, time.Time{}, ErrRefreshTokenExpired
@@ -78,51 +76,19 @@ func getRefreshedToken(client *oidc.Client, t string) (jose.JWT, time.Time, erro
 	return token, identity.ExpiresAt, nil
 }
 
-// exchangeAuthenticationCode exchanges the authentication code with the oauth server for a access token
-func exchangeAuthenticationCode(client *oauth2.Client, code string) (oauth2.TokenResponse, error) {
-	return getToken(client, oauth2.GrantTypeAuthCode, code)
-}
-
-// getUserinfo is responsible for getting the userinfo from the IDPD
-func getUserinfo(client *oauth2.Client, endpoint string, token string) (jose.Claims, error) {
-	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set(authorizationHeader, fmt.Sprintf("Bearer %s", token))
-
-	resp, err := client.HttpClient().Do(req)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, errors.New("token not validate by userinfo endpoint")
-	}
-	content, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	var claims jose.Claims
-	if err := json.Unmarshal(content, &claims); err != nil {
-		return nil, err
-	}
-
-	return claims, nil
-}
-
 // getToken retrieves a code from the provider, extracts and verified the token
-func getToken(client *oauth2.Client, grantType, code string) (oauth2.TokenResponse, error) {
+func getToken(config *oauth2.Config, grantType, code string) (*oauth2.Token, error) {
 	start := time.Now()
-	token, err := client.RequestToken(grantType, code)
+	token, err := config.Exchange(context.Background(), code)
 	if err != nil {
 		return token, err
 	}
 	taken := time.Since(start).Seconds()
 	switch grantType {
-	case oauth2.GrantTypeAuthCode:
+	case GrantTypeAuthCode:
 		oauthTokensMetric.WithLabelValues("exchange").Inc()
 		oauthLatencyMetric.WithLabelValues("exchange").Observe(taken)
-	case oauth2.GrantTypeRefreshToken:
+	case GrantTypeRefreshToken:
 		oauthTokensMetric.WithLabelValues("renew").Inc()
 		oauthLatencyMetric.WithLabelValues("renew").Observe(taken)
 	}


### PR DESCRIPTION
- Add OAuth2 constants to keep API backwards compatibility
- Added deprecation notice for exchangeAuthenticationCode
- Also replaces of UserCredsToken by golang/x/oauth API
- Replace getOAuthClient by getOAuthConfig
- Fully replacement of getRefreshToken and getToken
- Variable refactoring for consistency
- Removal of getUserInfo. This is part of OIDC spec, not OAuth2
and can be covered by coreos/go-oidc v2