### PR TITLE
Debug Profiling Warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ FEATURES:
 * Adding a ability to match string arrays claims [#PR364](https://github.com/gambol99/keycloak-proxy/pull/364)
 * Imported the fix to the cache headers from upstream go-oidc [#PR341](https://github.com/gambol99/keycloak-proxy/pull/341)
 * Switching to using SHA256 from MD5 for the token hash [#PR350](https://github.com/gambol99/keycloak-proxy/pull/350)
+* Added a warning messaage to indicate disabling the write-timeout when using pprof [#PR370](https://github.com/gambol99/keycloak-proxy/pull/370)
 
 FIXES:
 * Fixed up the redirect_uri to the logout [#PR365](https://github.com/gambol99/keycloak-proxy/pull/365)

--- a/server.go
+++ b/server.go
@@ -208,6 +208,10 @@ func (r *oauthProxy) createReverseProxy() error {
 			e.Get("/{name}", r.debugHandler)
 			e.Post("/{name}", r.debugHandler)
 		})
+		// @check if the server write-timeout is still set and throw a warning
+		if r.config.ServerWriteTimeout > 0 {
+			r.log.Warn("you must disable the server write timeout (--server-write-timeout) when using pprof profiling")
+		}
 	}
 
 	if r.config.EnableSessionCookies {


### PR DESCRIPTION
- throw a message to the user to disable server write-timeout when using pprof