### PR TITLE
Revert "GoProxy Dependency Revert (#366)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ FEATURES:
 * Added a warning messaage to indicate disabling the write-timeout when using pprof [#PR370](https://github.com/gambol99/keycloak-proxy/pull/370)
 
 FIXES:
-* Fixed up the redirect_uri to the logout [#PR365](https://github.com/gambol99/keycloak-proxy/pull/365)
 * Fixed a redirection bug [#PR337](https://github.com/gambol99/keycloak-proxy/pull/337)
 * Updated the go-oidc to fix the cache header [issues](https://github.com/gambol99/keycloak-proxy/issues/340)[#PR339](https://github.com/gambol99/keycloak-proxy/pull/339)
 * Fixed up the readme indicating we can run without client secret [#PR342](https://github.com/gambol99/keycloak-proxy/pull/342)

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -42,6 +42,12 @@
   revision = "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/elazarl/goproxy"
+  packages = ["."]
+  revision = "a96fa3a318260eab29abaf32f7128c9eb07fb073"
+
+[[projects]]
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
@@ -58,12 +64,6 @@
     "oidc"
   ]
   revision = "87948fe50989333a6a3f970e48f8dec844361fa1"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/gambol99/goproxy"
-  packages = ["."]
-  revision = "e713e5909438245be49ef559e74dd904833ebe90"
 
 [[projects]]
   name = "github.com/go-chi/chi"
@@ -240,6 +240,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b139b3100a36c39eb42630da4afe77e4f69afef6fbf7b03c7f12e5608d317b04"
+  inputs-digest = "fa706262e3b247b3e297d1c9e12bfefed7b4e7aa015f633af5877a9283d3459b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -39,7 +39,7 @@
 
 [[constraint]]
   branch = "master"
-  name = "github.com/gambol99/goproxy"
+  name = "github.com/elazarl/goproxy"
 
 [[constraint]]
   name = "github.com/rs/cors"

--- a/server.go
+++ b/server.go
@@ -37,8 +37,8 @@ import (
 	httplog "log"
 
 	proxyproto "github.com/armon/go-proxyproto"
+	"github.com/elazarl/goproxy"
 	"github.com/gambol99/go-oidc/oidc"
-	"github.com/gambol99/goproxy"
 	"github.com/pressly/chi"
 	"github.com/pressly/chi/middleware"
 	"github.com/prometheus/client_golang/prometheus"


### PR DESCRIPTION
This reverts commit a2849c0da2732aa140ae3561026c00ade3a36ac4.
Adds the upstream GoProxy back to the develop branch