### PR TITLE
Removal of HTTPClient

### DIFF
--- a/middleware_test.go
+++ b/middleware_test.go
@@ -92,7 +92,7 @@ func newFakeProxy(c *Config) *fakeProxy {
 	}
 	c.RedirectionURL = fmt.Sprintf("http://%s", proxy.listener.Addr().String())
 	// step: we need to update the client configs
-	if proxy.client, proxy.idp, proxy.idpClient, err = proxy.newOpenIDClient(); err != nil {
+	if proxy.client, proxy.idp, err = proxy.newOpenIDClient(); err != nil {
 		panic("failed to recreate the openid client, error: " + err.Error())
 	}
 

--- a/server_test.go
+++ b/server_test.go
@@ -419,7 +419,7 @@ func newTestProxyService(config *Config) (*oauthProxy, *fakeAuthServer, string) 
 	config.RedirectionURL = service.URL
 
 	// step: we need to update the client config
-	if proxy.client, proxy.idp, proxy.idpClient, err = proxy.newOpenIDClient(); err != nil {
+	if proxy.client, proxy.idp, err = proxy.newOpenIDClient(); err != nil {
 		panic("failed to recreate the openid client, error: " + err.Error())
 	}
 


### PR DESCRIPTION
As part of our migration to coreos/go-oidc v2, I've been doing some
clean up. While doing this I found out that HTTPClient is never used
and seems to be not necessary anymore

@gambol99 this is part of our plans to move to the upstream. I'd appreciate your feedback.