### PR TITLE
Add a flag to use HTTP 303 instead of HTTP 307 for invalid auth redirects

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -270,6 +270,8 @@ type Config struct {
 	// EncryptionKey is the encryption key used to encrypt the refresh token
 	EncryptionKey string `json:"encryption-key" yaml:"encryption-key" usage:"encryption key used to encryption the session state" env:"ENCRYPTION_KEY"`
 
+	// InvalidAuthRedirectsWith303 will make requests with invalid auth headers redirect using HTTP 303 instead of HTTP 307.  See github.com/gambol99/keycloak-proxy/issues/292 for context.
+	InvalidAuthRedirectsWith303 bool `json:"invalid-auth-redirects-with-303" yaml:"invalid-auth-redirects-with-303" usage:"use HTTP 303 redirects instead of 307 for invalid auth tokens"`
 	// NoRedirects informs we should hand back a 401 not a redirect
 	NoRedirects bool `json:"no-redirects" yaml:"no-redirects" usage:"do not have back redirects when no authentication is present, 401 them"`
 	// SkipTokenVerification tells the service to skipp verifying the access token - for testing purposes

--- a/handlers.go
+++ b/handlers.go
@@ -93,7 +93,7 @@ func (r *oauthProxy) oauthAuthorizationHandler(w http.ResponseWriter, req *http.
 		return
 	}
 
-	r.redirectToURL(authURL, w, req)
+	r.redirectToURL(authURL, w, req, http.StatusTemporaryRedirect)
 }
 
 // oauthCallbackHandler is responsible for handling the response from oauth service
@@ -208,7 +208,7 @@ func (r *oauthProxy) oauthCallbackHandler(w http.ResponseWriter, req *http.Reque
 		}
 	}
 
-	r.redirectToURL(state, w, req)
+	r.redirectToURL(state, w, req, http.StatusTemporaryRedirect)
 }
 
 // loginHandler provide's a generic endpoint for clients to perform a user_credentials login to the provider
@@ -338,7 +338,7 @@ func (r *oauthProxy) logoutHandler(w http.ResponseWriter, req *http.Request) {
 			}
 		}
 
-		r.redirectToURL(fmt.Sprintf("%s?redirect_uri=%s", sendTo, url.QueryEscape(redirectURL)), w, req)
+		r.redirectToURL(fmt.Sprintf("%s?redirect_uri=%s", sendTo, url.QueryEscape(redirectURL)), w, req, http.StatusTemporaryRedirect)
 
 		return
 	}
@@ -389,7 +389,7 @@ func (r *oauthProxy) logoutHandler(w http.ResponseWriter, req *http.Request) {
 	}
 	// step: should we redirect the user
 	if redirectURL != "" {
-		r.redirectToURL(redirectURL, w, req)
+		r.redirectToURL(redirectURL, w, req, http.StatusTemporaryRedirect)
 	}
 }
 

--- a/misc.go
+++ b/misc.go
@@ -83,8 +83,8 @@ func (r *oauthProxy) accessForbidden(w http.ResponseWriter, req *http.Request) c
 }
 
 // redirectToURL redirects the user and aborts the context
-func (r *oauthProxy) redirectToURL(url string, w http.ResponseWriter, req *http.Request) context.Context {
-	http.Redirect(w, req, url, http.StatusTemporaryRedirect)
+func (r *oauthProxy) redirectToURL(url string, w http.ResponseWriter, req *http.Request, statusCode int) context.Context {
+	http.Redirect(w, req, url, statusCode)
 
 	return r.revokeProxy(w, req)
 }
@@ -104,7 +104,11 @@ func (r *oauthProxy) redirectToAuthorization(w http.ResponseWriter, req *http.Re
 		w.WriteHeader(http.StatusForbidden)
 		return r.revokeProxy(w, req)
 	}
-	r.redirectToURL(r.config.WithOAuthURI(authorizationURL+authQuery), w, req)
+	if r.config.InvalidAuthRedirectsWith303 {
+		r.redirectToURL(r.config.WithOAuthURI(authorizationURL+authQuery), w, req, http.StatusSeeOther)
+	} else {
+		r.redirectToURL(r.config.WithOAuthURI(authorizationURL+authQuery), w, req, http.StatusTemporaryRedirect)
+	}
 
 	return r.revokeProxy(w, req)
 }

--- a/misc_test.go
+++ b/misc_test.go
@@ -42,6 +42,21 @@ func TestRedirectToAuthorization(t *testing.T) {
 	newFakeProxy(nil).RunTests(t, requests)
 }
 
+func TestRedirectToAuthorizationWith303Enabled(t *testing.T) {
+	cfg := newFakeKeycloakConfig()
+	cfg.InvalidAuthRedirectsWith303 = true
+
+	requests := []fakeRequest{
+		{
+			URI:              "/admin",
+			Redirects:        true,
+			ExpectedLocation: "/oauth/authorize?state=L2FkbWlu",
+			ExpectedCode:     http.StatusSeeOther,
+		},
+	}
+	newFakeProxy(cfg).RunTests(t, requests)
+}
+
 func TestRedirectToAuthorizationSkipToken(t *testing.T) {
 	requests := []fakeRequest{
 		{URI: "/admin", ExpectedCode: http.StatusUnauthorized},


### PR DESCRIPTION
This allows users to address the behavior reported in https://github.com/gambol99/keycloak-proxy/issues/292, while preserving the current behavior by default.