### PR TITLE
BaseURI parameter for deployments with non-root mount point

### DIFF
--- a/config.go
+++ b/config.go
@@ -61,7 +61,11 @@ func newDefaultConfig() *Config {
 
 // WithOAuthURI returns the oauth uri
 func (r *Config) WithOAuthURI(uri string) string {
-	return fmt.Sprintf("%s/%s", r.OAuthURI, uri)
+	if r.BaseURI != "" {
+		return fmt.Sprintf("%s/%s/%s", r.BaseURI, r.OAuthURI, uri)
+	} else {
+		return fmt.Sprintf("%s/%s", r.OAuthURI, uri)
+	}
 }
 
 // isValid validates if the config is valid

--- a/doc.go
+++ b/doc.go
@@ -162,6 +162,8 @@ type Config struct {
 	OpenIDProviderProxy string `json:"openid-provider-proxy" yaml:"openid-provider-proxy" usage:"proxy for communication with the openid provider"`
 	// OpenIDProviderTimeout is the timeout used to pulling the openid configuration from the provider
 	OpenIDProviderTimeout time.Duration `json:"openid-provider-timeout" yaml:"openid-provider-timeout" usage:"timeout for openid configuration on .well-known/openid-configuration"`
+	// BaseURI is prepended to all the generated URIs
+	BaseURI string `json:"base-uri" yaml:"base-uri" usage:"common prefix for all URIs" env:"BASE_URI"`
 	// OAuthURI is the uri for the oauth endpoints for the proxy
 	OAuthURI string `json:"oauth-uri" yaml:"oauth-uri" usage:"the uri for proxy oauth endpoints" env:"OAUTH_URI"`
 	// Scopes is a list of scope we should request

--- a/handlers.go
+++ b/handlers.go
@@ -207,6 +207,10 @@ func (r *oauthProxy) oauthCallbackHandler(w http.ResponseWriter, req *http.Reque
 			state = string(decoded)
 		}
 	}
+	if r.config.BaseURI != "" {
+		// assuming state starts with slash
+		state = r.config.BaseURI + state
+	}
 
 	r.redirectToURL(state, w, req, http.StatusTemporaryRedirect)
 }


### PR DESCRIPTION
See issue #331 

This pull request is my quick fix for the problem listed there. Basically, I've added BaseURI parameter which is used to prefix all generated URIs, so it works mounted at the non-root URI of the upstream proxy.