### PR TITLE
Migration to go-oidc from upstream v1

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -28,6 +28,18 @@
   revision = "144418e1475d8bf7abbdc48583500f1a20c62ea7"
 
 [[projects]]
+  branch = "v1"
+  name = "github.com/coreos/go-oidc"
+  packages = [
+    "http",
+    "jose",
+    "key",
+    "oauth2",
+    "oidc"
+  ]
+  revision = "e860bd55bfa7d7cb35d30d26a167982584f616b0"
+
+[[projects]]
   name = "github.com/coreos/pkg"
   packages = [
     "health",
@@ -42,28 +54,16 @@
   revision = "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d"
 
 [[projects]]
+  name = "github.com/elazarl/goproxy"
+  packages = ["."]
+  revision = "947c36da3153ff334e74d9d980de341d25f358ba"
+  version = "v1.1"
+
+[[projects]]
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
   version = "v1.4.7"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/gambol99/go-oidc"
-  packages = [
-    "http",
-    "jose",
-    "key",
-    "oauth2",
-    "oidc"
-  ]
-  revision = "87948fe50989333a6a3f970e48f8dec844361fa1"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/gambol99/goproxy"
-  packages = ["."]
-  revision = "e713e5909438245be49ef559e74dd904833ebe90"
 
 [[projects]]
   name = "github.com/go-chi/chi"
@@ -246,6 +246,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c239d30032133a01b89a8a62bd3abecf47284348176c0e9e2f295f9d65f46f55"
+  inputs-digest = "e7823fe27d5dc0e30e738df7a74ac04cd05bfd6e27f585e547312b6eac9fde9c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -34,12 +34,12 @@
   version = "1.4.7"
 
 [[constraint]]
-  branch = "master"
-  name = "github.com/gambol99/go-oidc"
+  branch = "v1"
+  name = "github.com/coreos/go-oidc"
 
 [[constraint]]
   branch = "master"
-  name = "github.com/gambol99/goproxy"
+  name = "github.com/elazarl/goproxy"
 
 [[constraint]]
   name = "github.com/rs/cors"

--- a/doc.go
+++ b/doc.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/gambol99/go-oidc/jose"
+	"github.com/coreos/go-oidc/jose"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -265,8 +265,6 @@ type Config struct {
 	TLSClientCertificate string `json:"tls-client-certificate" yaml:"tls-client-certificate" usage:"path to the client certificate for outbound connections in reverse and forwarding proxy modes"`
 	// SkipUpstreamTLSVerify skips the verification of any upstream tls
 	SkipUpstreamTLSVerify bool `json:"skip-upstream-tls-verify" yaml:"skip-upstream-tls-verify" usage:"skip the verification of any upstream TLS"`
-	// SkipClientID indicates we don't need to check the client id of the token
-	SkipClientID bool `json:"skip-client-id" yaml:"skip-client-id" usage:"skip the check on the client token"`
 
 	// CorsOrigins is a list of origins permitted
 	CorsOrigins []string `json:"cors-origins" yaml:"cors-origins" usage:"origins to add to the CORE origins control (Access-Control-Allow-Origin)"`

--- a/forwarding.go
+++ b/forwarding.go
@@ -20,8 +20,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/gambol99/go-oidc/jose"
-	"github.com/gambol99/go-oidc/oidc"
+	"github.com/coreos/go-oidc/jose"
+	"github.com/coreos/go-oidc/oidc"
 	"go.uber.org/zap"
 )
 

--- a/handlers.go
+++ b/handlers.go
@@ -30,7 +30,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gambol99/go-oidc/oauth2"
+	"github.com/coreos/go-oidc/oauth2"
 
 	"github.com/pressly/chi"
 	"go.uber.org/zap"

--- a/middleware.go
+++ b/middleware.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/PuerkitoBio/purell"
-	"github.com/gambol99/go-oidc/jose"
+	"github.com/coreos/go-oidc/jose"
 	"github.com/go-chi/chi/middleware"
 	uuid "github.com/satori/go.uuid"
 	"github.com/unrolled/secure"

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gambol99/go-oidc/jose"
+	"github.com/coreos/go-oidc/jose"
 	"github.com/go-resty/resty"
 	"github.com/rs/cors"
 	"github.com/stretchr/testify/assert"

--- a/misc.go
+++ b/misc.go
@@ -23,7 +23,7 @@ import (
 	"path"
 	"time"
 
-	"github.com/gambol99/go-oidc/jose"
+	"github.com/coreos/go-oidc/jose"
 	"go.uber.org/zap"
 )
 

--- a/oauth.go
+++ b/oauth.go
@@ -24,9 +24,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gambol99/go-oidc/jose"
-	"github.com/gambol99/go-oidc/oauth2"
-	"github.com/gambol99/go-oidc/oidc"
+	"github.com/coreos/go-oidc/jose"
+	"github.com/coreos/go-oidc/oauth2"
+	"github.com/coreos/go-oidc/oidc"
 )
 
 // getOAuthClient returns a oauth2 client from the openid client

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -28,8 +28,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gambol99/go-oidc/jose"
-	"github.com/gambol99/go-oidc/oauth2"
+	"github.com/coreos/go-oidc/jose"
+	"github.com/coreos/go-oidc/oauth2"
 	"github.com/pressly/chi"
 	"github.com/pressly/chi/middleware"
 	"github.com/stretchr/testify/assert"

--- a/server.go
+++ b/server.go
@@ -37,8 +37,8 @@ import (
 	httplog "log"
 
 	proxyproto "github.com/armon/go-proxyproto"
-	"github.com/gambol99/go-oidc/oidc"
-	"github.com/gambol99/goproxy"
+	"github.com/coreos/go-oidc/oidc"
+	"github.com/elazarl/goproxy"
 	"github.com/pressly/chi"
 	"github.com/pressly/chi/middleware"
 	"github.com/prometheus/client_golang/prometheus"
@@ -703,11 +703,10 @@ func (r *oauthProxy) newOpenIDClient() (*oidc.Client, oidc.ProviderConfig, *http
 			ID:     r.config.ClientID,
 			Secret: r.config.ClientSecret,
 		},
-		HTTPClient:        hc,
-		RedirectURL:       fmt.Sprintf("%s/oauth/callback", r.config.RedirectionURL),
-		ProviderConfig:    config,
-		Scope:             append(r.config.Scopes, oidc.DefaultScope...),
-		SkipClientIDCheck: r.config.SkipClientID,
+		HTTPClient:     hc,
+		RedirectURL:    fmt.Sprintf("%s/oauth/callback", r.config.RedirectionURL),
+		ProviderConfig: config,
+		Scope:          append(r.config.Scopes, oidc.DefaultScope...),
 	})
 	if err != nil {
 		return nil, config, hc, err

--- a/server_test.go
+++ b/server_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gambol99/go-oidc/jose"
+	"github.com/coreos/go-oidc/jose"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -345,44 +345,6 @@ func TestSkipClientIDDisabled(t *testing.T) {
 		{
 			URI:          "/auth_all/test",
 			RawToken:     badSigned.Encode(),
-			ExpectedCode: http.StatusForbidden,
-		},
-	}
-	p.RunTests(t, requests)
-}
-
-func TestSkipClientIDEnabled(t *testing.T) {
-	c := newFakeKeycloakConfig()
-	c.SkipClientID = true
-	p := newFakeProxy(c)
-	// create two token, one with a bad client id
-	bad := newTestToken(p.idp.getLocation())
-	bad.merge(jose.Claims{"aud": "bad_client_id"})
-	badSigned, _ := p.idp.signToken(bad.claims)
-	// and the good
-	good := newTestToken(p.idp.getLocation())
-	goodSigned, _ := p.idp.signToken(good.claims)
-	// bad issuer
-	badIssurer := newTestToken("http://someone_else")
-	badIssurer.merge(jose.Claims{"aud": "bad_client_id"})
-	badIssuerSigned, _ := p.idp.signToken(badIssurer.claims)
-
-	requests := []fakeRequest{
-		{
-			URI:           "/auth_all/test",
-			RawToken:      goodSigned.Encode(),
-			ExpectedProxy: true,
-			ExpectedCode:  http.StatusOK,
-		},
-		{
-			URI:           "/auth_all/test",
-			RawToken:      badSigned.Encode(),
-			ExpectedProxy: true,
-			ExpectedCode:  http.StatusOK,
-		},
-		{
-			URI:          "/auth_all/test",
-			RawToken:     badIssuerSigned.Encode(),
 			ExpectedCode: http.StatusForbidden,
 		},
 	}

--- a/session.go
+++ b/session.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gambol99/go-oidc/jose"
+	"github.com/coreos/go-oidc/jose"
 	"go.uber.org/zap"
 )
 

--- a/stores.go
+++ b/stores.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/gambol99/go-oidc/jose"
+	"github.com/coreos/go-oidc/jose"
 	"go.uber.org/zap"
 )
 

--- a/user_context.go
+++ b/user_context.go
@@ -20,8 +20,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gambol99/go-oidc/jose"
-	"github.com/gambol99/go-oidc/oidc"
+	"github.com/coreos/go-oidc/jose"
+	"github.com/coreos/go-oidc/oidc"
 )
 
 // extractIdentity parse the jwt token and extracts the various elements is order to construct
@@ -95,7 +95,7 @@ func extractIdentity(token jose.JWT) (*userContext, error) {
 	}, nil
 }
 
-// backported from https://github.com/gambol99/go-oidc/blob/master/oidc/verification.go#L28-L37
+// backported from https://github.com/coreos/go-oidc/blob/master/oidc/verification.go#L28-L37
 // I'll raise another PR to make it public in the go-oidc package so we can just use `oidc.ContainsString()`
 func containsString(needle string, haystack []string) bool {
 	for _, v := range haystack {

--- a/utils.go
+++ b/utils.go
@@ -44,7 +44,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/gambol99/go-oidc/jose"
+	"github.com/coreos/go-oidc/jose"
 	"github.com/urfave/cli"
 	"gopkg.in/yaml.v2"
 )


### PR DESCRIPTION
This change aims to make use of coreos/go-oidc. The generic adapter
aims to act as a sidecar, provide a way to SkipClientID is out of scope
for now.

That does not mean that we cannot revisit this in the near future.