### PR TITLE
Reduce cookie divide limit to 4000 bytes

### DIFF
--- a/cookies.go
+++ b/cookies.go
@@ -47,7 +47,7 @@ func (r *oauthProxy) dropCookie(w http.ResponseWriter, host, name, value string,
 // dropAccessTokenCookie drops a access token cookie into the response
 func (r *oauthProxy) dropAccessTokenCookie(req *http.Request, w http.ResponseWriter, value string, duration time.Duration) {
 	// also cookie name is included in the cookie length; cookie name suffix "-xxx"
-	maxCookieLength := 4089 - len(r.config.CookieAccessName)
+	maxCookieLength := 4000 - len(r.config.CookieAccessName)
 
 	if len(value) <= maxCookieLength {
 		r.dropCookie(w, req.Host, r.config.CookieAccessName, value, duration)
@@ -67,7 +67,7 @@ func (r *oauthProxy) dropAccessTokenCookie(req *http.Request, w http.ResponseWri
 // dropRefreshTokenCookie drops a refresh token cookie into the response
 func (r *oauthProxy) dropRefreshTokenCookie(req *http.Request, w http.ResponseWriter, value string, duration time.Duration) {
 	// also cookie name is included in the cookie length; cookie name suffix "-xxx"
-	maxCookieLength := 4089 - len(r.config.CookieRefreshName)
+	maxCookieLength := 4000 - len(r.config.CookieRefreshName)
 
 	if len(value) <= maxCookieLength {
 		r.dropCookie(w, req.Host, r.config.CookieRefreshName, value, duration)


### PR DESCRIPTION
Cookies have a size limit of 4096 bytes. Currently, cookies in this project are divided at 4089 bytes to accommodate, however it does not take into account the Path, Domain, and Expiration attributes of a cookie, which also count toward the limit.

This PR decreases the cookie size limit to 4000 bytes, which should account for most use cases (barring inordinately long DNS names). See issue #409 for more details.